### PR TITLE
round fractional seconds down with Math.floor

### DIFF
--- a/qml/hookandline_hookmatrix/DropsScreen.qml
+++ b/qml/hookandline_hookmatrix/DropsScreen.qml
@@ -291,7 +291,7 @@ Item {
     function padZeros(value) { return (value < 10) ? "0" + value : value; }
     function formatTime(value) {
         var minutes = padZeros(Math.floor(value/60))
-        var seconds = padZeros(Math.round(value%60))
+        var seconds = padZeros(Math.floor(value%60))
         return minutes + ":" + seconds;
     }
     function getHeaderTitle() {


### PR DESCRIPTION
avoid rounding fractions of sections up so we don't get 1:60 when clicking hookmatrix drop time buttons.  Fix #42 creating different branch.