### PR TITLE
HookMatrix: adding button to jump to hooks after gear perf

### DIFF
--- a/py/hookandline_hookmatrix/Drops.py
+++ b/py/hookandline_hookmatrix/Drops.py
@@ -544,7 +544,7 @@ class Drops(QObject):
 
         return hooks_lbl
 
-    @pyqtSlot(int, str, name="selectAnglerHooksLabel", result=QVariant)
+    @pyqtSlot(int, str, name="selectAnglerHooksLabel", result=str)
     def select_angler_hooks_label(self, drop_op_id: int, angler: str):
         """
         Select hooks per op_id aka angler from DB.
@@ -612,3 +612,5 @@ class Drops(QObject):
                 angler,
                 self.format_hooks_label(hooks_list)
             )
+            return self.format_hooks_label(hooks_list)  # return to use str outside of signal
+

--- a/py/hookandline_hookmatrix/GearPerformance.py
+++ b/py/hookandline_hookmatrix/GearPerformance.py
@@ -165,3 +165,4 @@ class GearPerformance(QObject):
                     params=[op_id, hook]
                 )
         logging.info(f"Angler {self._app.state_machine.angler} hooks set to 'Undeployed'")
+        self.hooksSetToUndeployed.emit()

--- a/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
+++ b/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
@@ -43,6 +43,7 @@ Item {
             }
             if (stop_processing) break;
         }
+        updateHooksLabel();
     }
 
     function updateButtonRelations(clickedBtnStr) {
@@ -94,7 +95,14 @@ Item {
             }
         }
     }
-
+    Connections {
+            target: gearPerformance
+            onHooksSetToUndeployed: updateHooksLabel();
+        } // after setting, update hooks label accordingly
+    function updateHooksLabel() {
+        console.warn("trying to update hooks label")
+         txtHooksGp.text = drops.selectAnglerHooksLabel(stateMachine.dropOpId, stateMachine.angler);
+    }
     Header {
         id: framHeader
         title: "Gear Performance: Drop " + stateMachine.drop + " - Angler " + stateMachine.angler
@@ -254,7 +262,34 @@ Item {
         } // btnNoProblems
 //        	-- No Problems (default value - use this if no performance issues identified)
 //	-- Lost Hook(s) -- Lost Gangion  -- Lost Sinker  -- Minor Tangle  -- Major Tangle  -- Undeployed
-
+            Rectangle { // TODO: add this QML obj as a separate file that can be reused here and in drops
+                id: rtHooksGp
+                antialiasing: true
+                height: 40
+                radius: 4
+                implicitWidth:  txtHooksGp.implicitWidth + imgHooksGp.implicitWidth
+                color: "transparent"
+                enabled: true
+                Text {
+                    id: txtHooksGp
+                    text: qsTr("Hooks")
+                    font.pixelSize: 24
+                    anchors.verticalCenter: parent.verticalCenter
+                    textFormat: Text.RichText
+                }
+                Image {
+                    id: imgHooksGp
+                    anchors.left: txtHooksGp.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: Qt.resolvedUrl("/resources/images/navigation_next_item_dark.png")
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: {
+                        smHookMatrix.to_hooks_state();
+                    }
+                }
+            } // rtHooks
     } // clPerformances
     OkayCancelDialog {
         id: dlgUndeployed
@@ -265,6 +300,7 @@ Item {
         onAccepted: { gearPerformance.setHooksToUndeployed() }
         onRejected: {}
     }
+
     Footer {
         id: framFooter
         height: 50

--- a/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
+++ b/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
@@ -86,12 +86,19 @@ DSM.StateMachine {
             targetState: drops_state
             signal: to_drops_state
         } // to_drops_state
+        DSM.SignalTransition {
+            targetState: hooks_state
+            signal: to_hooks_state
+        } // to_hooks_state
     } // gear_performance_state
     DSM.State {
         id: hooks_state
         onEntered: {
             stateMachine.previousScreen = stateMachine.screen;
-            stateMachine.screen = "hooks"
+            stateMachine.screen = "hooks";
+            if (stateMachine.previousScreen === "gear_performance") {
+                screens.pop();  // keep either gp or hooks one step away from drops
+            }
             screens.push(Qt.resolvedUrl("HooksScreen.qml"));
             hooks.selectHooks();
         }


### PR DESCRIPTION
1. GearPerformanceScreen now has widget that mirrors the Hooks label from drops
2. Call updateHooksLabel() in GP on screen load or when user sets all hooks to undeployed
3.  For now make sure state machine pops GearPerformance when going to hooks, so the back button still takes you to Drops from Hooks.

#143 
