### PR TITLE
filter inactive vessel contacts for captains property

### DIFF
--- a/py/observer/ObserverData.py
+++ b/py/observer/ObserverData.py
@@ -173,6 +173,7 @@ class ObserverData(QObject):
                 join(VesselContacts, on=(Contacts.contact == VesselContacts.contact)). \
                 where(
                 (Contacts.contact_category == 3) &  # Vessel category
+                (VesselContacts.contact_status != 'NA') &
                 (VesselContacts.vessel == self._captain_vessel_id) &  # Vessel ID
                 ((VesselContacts.contact_type == 1) |  # Skipper
                  (VesselContacts.contact_type == 3)))  # Skipper/ Owner
@@ -180,6 +181,7 @@ class ObserverData(QObject):
             captains_q = Contacts.select(). \
                 join(VesselContacts, on=(Contacts.contact == VesselContacts.contact)). \
                 where(
+                (VesselContacts.contact_status != 'NA') &
                 (Contacts.contact_category == 3) &  # Vessel
                 ((VesselContacts.contact_type == 1) |  # Skipper
                  (VesselContacts.contact_type == 3)))  # Skipper/ Owner


### PR DESCRIPTION
Fixes [FIELD-1837](https://www.fisheries.noaa.gov/jira/browse/FIELD-1837), sets filter to only active captains on ObserverData.captains property, used by AutoComplete class.