### PR TITLE
Optecs wm5 zmis fix3

### DIFF
--- a/py/observer/Hauls.py
+++ b/py/observer/Hauls.py
@@ -34,6 +34,7 @@ class Hauls(QObject):
     maxVesselRetModelLengthChanged = pyqtSignal(int, name='maxVesselRetModelLengthChanged')
     currentBiolistNumChanged = pyqtSignal(name='currentBiolistNumChanged')
     unusedSignal = pyqtSignal(name='unusedSignal')  # quiet warnings
+    otcWeightChanged = pyqtSignal(name='otcWeightChanged')
 
     def __init__(self, db):
         super().__init__()
@@ -403,6 +404,9 @@ class Hauls(QObject):
 
         logging.debug('Set {} to {}'.format(data_name, data_val))
         self.modelChanged.emit()
+
+        if data_name == 'observer_total_catch':
+            self.otcWeightChanged.emit()
 
     def _lookup_target_strat_id(self, strat: str):
         """

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -733,7 +733,7 @@ class ObserverCatches(QObject):
                     # (Strictly speaking, this corner case could be limited to catch categories without a mapped
                     # species, but WM7s and WM14s aren't likely to want to add spec composition or biospecimens records,
                     # so defaulting to NSC seems reasonable. And the user can change SM explicitly and add records.)
-                    elif self.wmIsEitherVesselEstimateOrVisualExperience:
+                    elif self.wmNoSpeciesCompRequired:
                         sample_method = self.SM_NO_SPECIES_COMP
 
                 except Exception as e:
@@ -805,7 +805,7 @@ class ObserverCatches(QObject):
         # current weight method is either 7 (vessel estimate) or 14 (visual experience).
         # This should have been checked before getting here. Raise exception if not the case.
         if new_sm == self.SM_NO_SPECIES_COMP:
-            if not cc_has_matching_species and not self.wmIsEitherVesselEstimateOrVisualExperience:
+            if not cc_has_matching_species and not self.wmNoSpeciesCompRequired:
                 raise Exception("Catch without matching species cannot have sample method of NSC unless WM7 or WM14.")
 
         self._is_species_comp = new_sm
@@ -929,11 +929,14 @@ class ObserverCatches(QObject):
             return ''
 
     @pyqtProperty(QVariant, notify=unusedSignal)
-    def wmIsEitherVesselEstimateOrVisualExperience(self):
+    def wmNoSpeciesCompRequired(self):
+        """
+        true if WM is allowed Species Comp = NO
+        :return: boolean
+        """
         if not self._current_catch:
             return False
-        ret_val = self._current_catch.catch_weight_method in ['7', '14']
-        return ret_val
+        return self._current_catch.catch_weight_method in ['5', '7', '14']
 
     def _wm_uses_counts_and_weights_tab(self):
         """

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.1+5"
+optecs_version = "2.1.1+8"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.1+10"
+optecs_version = "2.1.1+13"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.1+9">
+optecs_version = "2.1.1+10"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/qml/observer/CatchCategoriesDetailsFGScreen.qml
+++ b/qml/observer/CatchCategoriesDetailsFGScreen.qml
@@ -395,7 +395,7 @@ Item {
                                     // Reason: Biospecimens can be allowed with SM=NSC only if the Catch Category
                                     // has a mapped species (there's no default species, and there's no access to
                                     // the Species tab when SM=NSC).
-                                    if (appstate.catches.wmIsEitherVesselEstimateOrVisualExperience &&
+                                    if (appstate.catches.wmNoSpeciesCompRequired &&
                                             modelData != 14 &&
                                             appstate.catches.currentSampleMethodIsNoSpeciesComposition &&
                                             (appstate.catches.currentMatchingSpeciesId === null)) {
@@ -646,7 +646,7 @@ Item {
                             onClicked: {
                                 if (enabled) {
                                     if (appstate.catches.currentMatchingSpeciesId == null) {
-                                        if (appstate.catches.wmIsEitherVesselEstimateOrVisualExperience) {
+                                        if (appstate.catches.wmNoSpeciesCompRequired) {
                                             console.debug("NSC allowed, even with CC with no mapped species, " +
                                                     "because WM is either 7 (vessel est.) or 14 (viz exp).");
                                         } else {

--- a/qml/observer/CatchCategoriesScreen.qml
+++ b/qml/observer/CatchCategoriesScreen.qml
@@ -520,7 +520,6 @@ Item {
                     return false;
                 }
                 var selectedCC = model.get(currentRow);  // Not just currentIndex!
-
                 appstate.catches.currentCatch = selectedCC;
                 appstate.catchCatName = selectedCC.catch_category_code;
                 console.debug("Set appstate.catchCatName to '" + appstate.catchCatName + "'.");
@@ -551,10 +550,14 @@ Item {
                 tabView.selectedCatchCatChanged(); // Notify.
                 return true;
             }
-
-
+//            Connections { // when wm5 wt changes in DB, refresh in tableView / "currentCatch" too
+//                target: appstate
+//                onWm5WeightChanged: tvSelectedCatchCat.refreshWM5Weights(catchId, new_wt)
+//            }
             Connections {
                 target: appstate.catches
+
+                onRefreshTvWm5Weights: tvSelectedCatchCat.refreshWm5Weights(catchId, newWt)
 
                 onSampleMethodChanged : {
                     console.debug("Connection in tvSelectedCatchCat received sample method change to " + sample_method);
@@ -683,6 +686,23 @@ Item {
                 if (newRow >= 0) {
                     selectRow(newRow);
                 }
+            }
+
+            function refreshWm5Weights(catchId, newWt) {
+                // needed when retained wt changed, OTC-RET must change too
+                console.info("Refreshing WM5 Catch weight (CatchID: )" + catchId)
+                var lastSelected = getSelRow()
+                for(var i = 0; i < model.count; i++){
+                    if (model.get(i).catch === catchId) {
+                        // find WM5 catch, select, set as currentCatch, and set as new_wt
+                        selectRow(i);
+                        appstate.catches.currentCatch = getSelItem();
+                        appstate.catches.setData("catch_weight", newWt)
+                    }
+                }
+                // reselect original catch
+                selectRow(lastSelected)
+                appstate.catches.currentCatch = getSelItem()
             }
 
             function editItemDetails(item_index) {

--- a/qml/observer/ObserverSM.qml
+++ b/qml/observer/ObserverSM.qml
@@ -749,6 +749,7 @@ DSM.StateMachine {
             rightButtonStateName = "tabs_screen";
             titleText = "Details: " + btCatchCategory;
         }
+        onExited: appstate.catches.refreshWm5Weights()
         DSM.SignalTransition {
             targetState: cc_entry_state
             signal: to_previous_state
@@ -977,6 +978,8 @@ DSM.StateMachine {
             setSpeciesText();
             observerSM.enteringCW();
         }
+
+        onExited: appstate.catches.refreshWm5Weights();
 
         Connections {
             target: appstate


### PR DESCRIPTION
Fix for https://www.fisheries.noaa.gov/jira/browse/FIELD-1894.

Changes relate to trawl weight method 5, which is only allowed use with discarded ZMIS CC and a Species Comp = No.  The WM5 catch weight is calculated by taking the OTC minus all retained weights from the haul.  Anytime a retained entry is altered or the OTC is altered, this weight needs to update.  Summary of the changes in the app is below:

1. WM5 button is only visible when ZMIS is selected
2. When WM5 is selected, Species Comp. = Yes button is hidden, and Species Comp. = No is autoselected
3. the text field for Calculated Weight is the only field visible on the right-hand side of the CC Details Screen
4. This field is readonly and autopopulated with the OTC-RET calculated value
5. If the OTC value is changed, any WM5 catch weight should update
6. If a retained catch is added, changed, or deleted, the WM5 catch weight should update
7. The current weight needs to be refreshed in the table view where selected CCs are displayed in the CC Entry screen.  This table is a pain to update, especially with weights outside of the selected weight.