### PR TITLE
Optecs filter targetccs

### DIFF
--- a/py/observer/CatchCategory.py
+++ b/py/observer/CatchCategory.py
@@ -10,6 +10,7 @@
 
 import json
 import logging
+from peewee import fn
 from operator import itemgetter
 from typing import Dict, List
 import unittest
@@ -304,8 +305,10 @@ class CatchCategory(QObject):
         """
         active_catch_categories = []
 
-        catch_category_q = CatchCategories.select().where(CatchCategories.active >> None). \
-            order_by(CatchCategories.catch_category_code)
+        catch_category_q = CatchCategories.select().where(
+            (CatchCategories.active >> None) &
+            (~fn.Lower(CatchCategories.catch_category_name).contains('- target'))  # FIELD-1219
+        ). order_by(CatchCategories.catch_category_code)
 
         for cc in catch_category_q:
             active_catch_categories.append(model_to_dict(cc))

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.2+0"
+optecs_version = "2.1.2+1"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2


### PR DESCRIPTION
fix for https://www.fisheries.noaa.gov/jira/browse/FIELD-1219.  Filtering out any CC name that contains the substring "- Target" from the CC selection tableview.  @SaOgaz-NOAA fyi, gonna go ahead and merge, just a one-line change for this fix.