### PR TITLE
fix FIELD-2038: displaying catch_num and species_comp_item_id

### DIFF
--- a/qml/observer/CatchCategoriesScreen.qml
+++ b/qml/observer/CatchCategoriesScreen.qml
@@ -720,12 +720,15 @@ Item {
             function editItemBaskets(item_index) {  // For WM3 catch-level basket data
                 var ccBasketsPage = stackView.push(Qt.resolvedUrl("CatchCategoriesBasketsScreen.qml"));
             }
-
+            TableViewColumn {
+                role: "catch_num"
+                title: "#"
+                width: 42
+            }
             TableViewColumn {
                 role: "catch_disposition"
                 title: "R/D"
                 width: 55
-
             }
             TableViewColumn {
                 role: "catch_category_code"

--- a/qml/observer/SpeciesScreen.qml
+++ b/qml/observer/SpeciesScreen.qml
@@ -546,6 +546,11 @@ Item {
                 }
             }
             TableViewColumn {
+                role: "species_comp_item"
+                title: "#"
+                width: 42
+            }
+            TableViewColumn {
                 role: "common_name"
                 title: "Name"
                 width: 160


### PR DESCRIPTION
Adds Catch Num and Species Comp Item ID to CatchCategoriesScreen and SpeciesScreen selection tables: https://www.fisheries.noaa.gov/jira/browse/FIELD-2038 @SaOgaz-NOAA fyi