### PR TITLE
Optecs sort cc spp tables

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.2+3"
+optecs_version = "2.1.2+4"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/qml/observer/CatchCategoriesFGScreen.qml
+++ b/qml/observer/CatchCategoriesFGScreen.qml
@@ -383,14 +383,13 @@ Item {
 
                 // Highlight new entry in Selected Catch Categories.
                 if (tvSelectedCatchCat.model.count >= 1) {
-                    tvSelectedCatchCat.selectNewest();
+                    tvSelectedCatchCat.selectRow(0);
                     console.debug("Selected newest entry in Selected Catch Category.");
                 }
 
                 // automatically jump to CC details
                 obsSM.state_change("cc_details_state");
-                var newestEntry = tvSelectedCatchCat.getNewestRowIdx();
-                tvSelectedCatchCat.editItemDetails(newestEntry);
+                tvSelectedCatchCat.editItemDetails(0);
             }
 
             function removeCatchCat() {
@@ -480,6 +479,7 @@ Item {
             width: login.width - tvAvailableCC.width - columnAvailableCC.width - 90
             height: tvAvailableCC.height + tfCatchCategory.height
             selectionMode: SelectionMode.SingleSelection
+            sortable: true
 
             model: appstate.catches.CatchesModel
             // Sorting column (catch(_id)) isn't visible, but use this attribute to determine how model is sorted.
@@ -646,16 +646,17 @@ Item {
                 console.debug("Row " + tvSelectedCatchCat.currentRow + " highlighted.");
             }
 
-            function getSelRow() {
-                return currentRow;
-            }
-
-            function getSelItem() {
-                // Get currently selected item
-                var selected_row = getSelRow();
-                if (selected_row < 0)
-                    return null;
-                return model.get(selected_row);
+            onSorted: {
+                if (currentRow > -1) {
+                    // make highlighted row follow model sort
+                    var catchNum = tvSelectedCatchCat.getSelItem().catch_num
+                    tvSelectedCatchCat.selection.clear()
+                    model.sort(col)  // col var emitted from sorted signal in ObserverTableView
+                    currentRow = tvSelectedCatchCat.model.get_item_index('catch_num', catchNum)
+                    tvSelectedCatchCat.selection.select(currentRow)
+                } else { // nothing selected, just sort
+                    model.sort(col)
+                }
             }
 
             function getNewestRowIdx() {

--- a/qml/observer/CatchCategoriesScreen.qml
+++ b/qml/observer/CatchCategoriesScreen.qml
@@ -378,14 +378,13 @@ Item {
 
                 // Highlight new entry in Selected Catch Categories.
                 if (tvSelectedCatchCat.model.count >= 1) {
-                    tvSelectedCatchCat.selectNewest();
+                    tvSelectedCatchCat.selectRow(0);
                     console.debug("Selected newest entry in Selected Catch Category.");
                 }
 
                 // automatically jump to CC details
                 obsSM.state_change("cc_details_state");
-                var newestEntry = tvSelectedCatchCat.getNewestRowIdx();
-                tvSelectedCatchCat.editItemDetails(newestEntry);
+                tvSelectedCatchCat.editItemDetails(0);
             }
 
             function removeCatchCat() {

--- a/qml/observer/CatchCategoriesScreen.qml
+++ b/qml/observer/CatchCategoriesScreen.qml
@@ -475,6 +475,7 @@ Item {
             width: login.width - tvAvailableCC.width - columnAvailableCC.width - 90
             height: tvAvailableCC.height + tfCatchCategory.height
             selectionMode: SelectionMode.SingleSelection
+            sortable: true
 
             model: appstate.catches.CatchesModel
             // Sorting column (catch(_id)) isn't visible, but use this attribute to determine how model is sorted.
@@ -653,16 +654,17 @@ Item {
                 console.debug("Row " + tvSelectedCatchCat.currentRow + " highlighted.");
             }
 
-            function getSelRow() {
-                return currentRow;
-            }
-
-            function getSelItem() {
-                // Get currently selected item
-                var selected_row = getSelRow();
-                if (selected_row < 0)
-                    return null;
-                return model.get(selected_row);
+            onSorted: {
+                if (currentRow > -1) {
+                    // make highlighted row follow model sort
+                    var catchNum = tvSelectedCatchCat.getSelItem().catch_num
+                    tvSelectedCatchCat.selection.clear()
+                    model.sort(col)  // col var emitted from sorted signal in ObserverTableView
+                    currentRow = tvSelectedCatchCat.model.get_item_index('catch_num', catchNum)
+                    tvSelectedCatchCat.selection.select(currentRow)
+                } else { // nothing selected, just sort
+                    model.sort(col)
+                }
             }
 
             function getNewestRowIdx() {
@@ -720,6 +722,7 @@ Item {
             function editItemBaskets(item_index) {  // For WM3 catch-level basket data
                 var ccBasketsPage = stackView.push(Qt.resolvedUrl("CatchCategoriesBasketsScreen.qml"));
             }
+
             TableViewColumn {
                 role: "catch_num"
                 title: "#"

--- a/qml/observer/ObserverTableView.qml
+++ b/qml/observer/ObserverTableView.qml
@@ -7,9 +7,22 @@ import "../common"
 // bug https://bugreports.qt.io/browse/QTBUG-49360 show width binding loop
 TableView {
     property int item_height: 50
+    property bool sortable: false  // allow basic table sorting to be turned on
+    signal sorted(string col)  // emit col name when table sorted (e.g. sorted("catch_num"))
+
     horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
     verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
 
+    function getSelRow() {
+        return currentRow;
+    }
+    function getSelItem() {
+        // Get currently selected item
+        var selected_row = getSelRow();
+        if (selected_row < 0)
+            return null;
+        return model.get(selected_row);
+    }
     style: TableViewStyle {
 
         itemDelegate: Item {
@@ -78,6 +91,16 @@ TableView {
                     GradientStop { position: 1.0; color: "#eee" }
                 }
             }
+            Connections {
+                target: styleData
+                onPressedChanged: {
+                    // why does this run 4 times when header clicked? TODO: replace with MouseArea --> onClicked?
+                    if (sortable) {
+                        sorted(getColumn(styleData.column).role)
+                    }
+                }
+            }
         }
     }
 }
+

--- a/qml/observer/SpeciesFGScreen.qml
+++ b/qml/observer/SpeciesFGScreen.qml
@@ -485,6 +485,8 @@ Item {
             width: main.width - tvAvailableSpecies.width - columnAvailableSpecies.width - 90
             height: tvAvailableSpecies.height + tfSpeciesFilter.height
             headerVisible: true
+            sortable: true
+            property bool isSorting: false
 
             model: appstate.catches.species.observerSpeciesSelectedModel
             // Sorting column (catch(_id)) isn't visible, but use this attribute to determine how model is sorted.
@@ -494,7 +496,7 @@ Item {
                 if (rowCount == 0) {
                     tvSelectedSpecies.clear_selection();
                 }
-                else {
+                else if (!isSorting) {
                     // Initialization of "downstream" tab screens (Counts/Weights and Biospecimens)
                     // depends upon the Species screen having selected an entry in the Selected species.
                     // Somewhat arbitrary, but reasonable choice: select the top entry.
@@ -691,6 +693,23 @@ Item {
                 activate_selected_species();
                 enable_remove_button(true);
             }
+
+            onSorted: {
+                // make highlighted row follow model sort TODO: Consolidate functionality to ObserverTableView
+                tvSelectedSpecies.isSorting = true  // use to silence onRowCountChanged signal
+                if (currentRow > -1) {
+                    var speciesCompItem = getSelItem().species_comp_item
+                    tvSelectedSpecies.selection.clear();
+                    model.sort(col)
+                    currentRow = tvSelectedSpecies.model.get_item_index('species_comp_item', speciesCompItem)
+                    tvSelectedSpecies.selection.select(currentRow)
+                    tvSelectedSpecies.activate_selected_species()
+                } else { // nothing selected, just sort
+                    model.sort(col)
+                }
+                tvSelectedSpecies.isSorting = false
+            }
+
         }
         RowLayout {
             x: tvSelectedSpecies.x

--- a/qml/observer/SpeciesScreen.qml
+++ b/qml/observer/SpeciesScreen.qml
@@ -483,6 +483,8 @@ Item {
             width: main.width - tvAvailableSpecies.width - columnAvailableSpecies.width - 90
             height: tvAvailableSpecies.height + tfSpeciesFilter.height
             headerVisible: true
+            sortable: true
+            property bool isSorting: false
 
             model: appstate.catches.species.observerSpeciesSelectedModel
             // Sorting column (catch(_id)) isn't visible, but use this attribute to determine how model is sorted.
@@ -492,7 +494,7 @@ Item {
                 if (rowCount == 0) {
                     tvSelectedSpecies.clear_selection();
                 }
-                else {
+                else if (!isSorting){
                     // Initialization of "downstream" tab screens (Counts/Weights and Biospecimens)
                     // depends upon the Species screen having selected an entry in the Selected species.
                     // Somewhat arbitrary, but reasonable choice: select the top entry.
@@ -682,6 +684,22 @@ Item {
                 appstate.speciesName = "";
 
                 enable_remove_button(false);
+            }
+
+            onSorted: {
+                // make highlighted row follow model sort TODO: Consolidate functionality to ObserverTableView
+                tvSelectedSpecies.isSorting = true  // use to silence onRowCountChanged signal
+                if (currentRow > -1) {
+                    var speciesCompItem = getSelItem().species_comp_item
+                    tvSelectedSpecies.selection.clear();
+                    model.sort(col)
+                    currentRow = tvSelectedSpecies.model.get_item_index('species_comp_item', speciesCompItem)
+                    tvSelectedSpecies.selection.select(currentRow)
+                    tvSelectedSpecies.activate_selected_species()
+                } else { // nothing selected, just sort
+                    model.sort(col)
+                }
+                tvSelectedSpecies.isSorting = false
             }
 
             onClicked: {


### PR DESCRIPTION
Changes allow TableView sorting to me enabled for Selected CC and Species screens:

1. Add sortable property and sorted signal to ObserverTableView
2. Emit signal when headerDelegate is clicked for sortable ObserverTableView
3. Run custom functionality for selected CC and species tv when sorted is emited
4. Consolidate getSelRow and getSelItem into ObserverTableView

https://www.fisheries.noaa.gov/jira/browse/FIELD-2036
https://www.fisheries.noaa.gov/jira/browse/FIELD-1874
