### PR TITLE
Suggest backup after successful trip sync

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.2+8"
+optecs_version = "2.1.2+9"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBSyncController.py
+++ b/py/observer/ObserverDBSyncController.py
@@ -46,6 +46,7 @@ class ObserverDBSyncController(QObject):
     readyToPush = pyqtSignal(name='readyToPush')
     dbSyncTimeChanged = pyqtSignal(name='dbSyncTimeChanged')
     userInfoChanged = pyqtSignal(name='userInfoChanged')
+    suggestBackup = pyqtSignal(name='suggestBackup')
 
     desc = {DBSyncStatusEnum.TRIP_IN_PROGRESS: 'Trip in Progress',
             DBSyncStatusEnum.SYNC_READY: 'Ready to Sync',

--- a/qml/observer/ObserverDBSyncDialog.qml
+++ b/qml/observer/ObserverDBSyncDialog.qml
@@ -95,7 +95,8 @@ Dialog {
             lblStatus.font.pixelSize = 25;
             lblBackupReminder.visible = false;
         } else {
-            btnCancelOK.text = "OK"
+            btnCancelOK.text = download_only ? "Ok" : "OK, Let's back it up"
+            btnCancelOK.backupSuggested = download_only ? false : true
             lblStatus.color = "green";
             lblStatus.font.bold = true;
             lblStatus.font.pixelSize = 25;
@@ -242,8 +243,15 @@ Dialog {
             id: btnCancelOK
             Layout.alignment: Qt.AlignCenter
             text: "Cancel"
+            property bool backupSuggested: false
             onClicked: {
+                if (backupSuggested) {
+                    db_sync.suggestBackup()
+                }
+                text: "Cancel"  // reset to defaults
+                backupSuggested = false  // might not be needed, but just in case
                 dlg.close()
+
             }
         }
 

--- a/qml/observer/ObserverHome.qml
+++ b/qml/observer/ObserverHome.qml
@@ -314,6 +314,15 @@ Item {
         }
     }
 
+    Connections {
+        target: db_sync
+        onSuggestBackup: goToBackup()
+    }
+    function goToBackup() {
+        obsSM.state_change("backup_state");
+        stackView.push(Qt.resolvedUrl("BackupScreen.qml"))
+    }
+
     function goToTripErrors() {
         obsSM.state_change("trip_errors_state");
         stackView.push(Qt.resolvedUrl("TripErrorReportsScreen.qml"))


### PR DESCRIPTION
Clicking "OK, lets back it up" directs user to backups screen after syncing trip. See https://www.fisheries.noaa.gov/jira/browse/FIELD-2066