### PR TITLE
FIELD-1698: FG Matrix Weight entry for CW screen

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.2+20"
+optecs_version = "2.1.2+27"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverSoundPlayer.py
+++ b/py/observer/ObserverSoundPlayer.py
@@ -137,6 +137,7 @@ class SoundPlayer(QObject):
                   'numpadDecimal': 'resources/sounds/minimal-ui-sounds/tinyclick.wav',
                   'numpadBack': 'resources/sounds/minimal-ui-sounds/click3.wav',
                   'numpadOK': 'resources/sounds/minimal-ui-sounds/beep.mp3',
+                  'matrixWtSel': 'resources/sounds/minimal-ui-sounds/beep.mp3',
                   'keyOK': 'resources/sounds/minimal-ui-sounds/beep.mp3',
                   'click': 'resources/sounds/minimal-ui-sounds/click2.wav',
                   'saveRecord': 'resources/sounds/minimal-ui-sounds/funnyclick.wav',

--- a/qml/observer/CountsWeightsFGScreen.qml
+++ b/qml/observer/CountsWeightsFGScreen.qml
@@ -509,7 +509,6 @@ Item {
                                 NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.MANUAL_WEIGHT, btnEditBasket.checked);
                             }
                         }
-
                     }
                     ObserverGroupButton {
                         id: btnManualCount
@@ -545,6 +544,46 @@ Item {
                                 btnEditBasket.visible = true
                             }
 
+                        }
+                    }
+                    // FIELD-1698: allow matrix increment toggle
+                    ExclusiveGroup {
+                        id: egMatrixToggle
+                    }
+                    ColumnLayout {
+                        // buttons allow user to change matrix increments
+                        id: clMatrixToggle
+                        visible: btnMatrixWeight.checked  // only when matrix is active
+                        ObserverGroupButton {
+                            id: btnTenthsMatrix
+                            text: "0.1"
+                            font_size: 13
+                            exclusiveGroup: egMatrixToggle
+                            Layout.preferredWidth: idEntry.default_width / 8
+                            Layout.preferredHeight: buttonLogin.height / 2
+                            onCheckedChanged: {
+                                if (checked) { // changing vals should change matrix dynamically
+                                    wtMatrix.step = parseFloat(btnTenthsMatrix.text)
+                                    wtMatrix.lowerRange = parseFloat(btnTenthsMatrix.text)
+                                    wtMatrix.upperRange = 6  // arbitrary, (6*.1) divides by 4 equally
+                                }
+                            }
+                        }
+                        ObserverGroupButton {
+                            id: btnQuartersMatrix
+                            text: "0.25"
+                            checked: true  // default to 0.25
+                            font_size: 12
+                            exclusiveGroup: egMatrixToggle
+                            Layout.preferredWidth: idEntry.default_width / 8
+                            Layout.preferredHeight: buttonLogin.height / 2
+                            onCheckedChanged: {
+                                if(checked) { // changing vals should change matrix dynamically
+                                    wtMatrix.step = parseFloat(btnQuartersMatrix.text)
+                                    wtMatrix.lowerRange = parseFloat(btnQuartersMatrix.text)
+                                    wtMatrix.upperRange = 21
+                                }
+                            }
                         }
                     }
                 }

--- a/qml/observer/CountsWeightsFGScreen.qml
+++ b/qml/observer/CountsWeightsFGScreen.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.2
-import QtQuick.Layouts 1.2
+import QtQuick.Layouts 1.3
 import QtQuick.Controls.Private 1.0
 
 import "../common"
@@ -15,7 +15,7 @@ Item {
     // Properties, Functions and Pop-up Dialogs
     ////
     property bool stateCW: false // set by signals, true if in CW state
-
+    property bool is_mix: appstate.catches.species.currentSpeciesItemName === 'MIX'
     property int dec_places: appstate.displayDecimalPlaces  // Number of decimal places to display weight values
 
     Connections {
@@ -155,6 +155,7 @@ Item {
             tvBaskets.selection.clear();
             btnManualWeight.checked = true;
             btnManualCount.enabled = false;  // Disable until editing existing basket.
+            btnMatrixWeight.enabled = true;
             numPad.show_no_weight(true);
             numPad.setSkipButtonMode(false);
             numPad.clearnumpad();
@@ -498,6 +499,7 @@ Item {
                         exclusiveGroup: egMeasurementType
                         onCheckedChanged: {
                             if (checked) {
+                                numPadStack.currentIndex = 0
                                 if (tvBaskets.currentRow != -1) {
                                     numPad.setnumpadvalue(tvBaskets.model.get(tvBaskets.currentRow).basket_weight_itq);
                                     numPad.selectAll();
@@ -527,212 +529,248 @@ Item {
                             }
                         }
                     }
+                    ObserverGroupButton {  // FIELD-1698: enable matrix weight entry
+                        id: btnMatrixWeight
+                        text: "Matrix\nWeight"
+                        exclusiveGroup: egMeasurementType
+                        visible: screenCW.speciesIsCounted()  // Species 'MIX' is weighed but not counted
+                        enabled: !btnManualCount.checked && !btnEditBasket.checked  // no matrix while editing
+                        onCheckedChanged: {
+                            if (checked) {
+                                numPadStack.currentIndex = 1
+                                btnEditBasket.visible = false
+                                NBSM.isEnteringMatrixBasket()
+                            } else {
+                                modeSC.reset();  // revert back to ready for basket wt state
+                                btnEditBasket.visible = true
+                            }
+
+                        }
+                    }
                 }
                 Row {
-                    FramNumPadMultiply {
-                        id: numPad
-                        x: 175
-                        y: 300
-                        state: "weights"
-                        limitToTwoDecimalPlaces: true   // Don't allow more than two decimal places for weight.
-                        enable_audio: ObserverSettings.enableAudio
-                        onNumpadok: {
+                    StackLayout {
+                        id: numPadStack
+                        FramNumPadMultiply {
+                            id: numPad
+                            x: 175
+                            y: 300
+                            state: "weights"
+                            limitToTwoDecimalPlaces: true   // Don't allow more than two decimal places for weight.
+                            enable_audio: ObserverSettings.enableAudio
+                            onNumpadok: {
 
 
-                            // If nothing is selected, do nothing
-                            if (tvBaskets.currentRow == -1 ||
-                                    (!gridDR.is_dr_set() && !appstate.catches.species.isRetained))
-                                return;
+                                // If nothing is selected, do nothing
+                                if (tvBaskets.currentRow == -1 ||
+                                        (!gridDR.is_dr_set() && !appstate.catches.species.isRetained))
+                                    return;
 
-//                             If zero, OK for FG Weights
-                            if ( stored_result === "0" && btnManualCount.checked) {
-                                console.log("Zero value- ignoring basket OK for FG count");
+    //                             If zero, OK for FG Weights
+                                if ( stored_result === "0" && btnManualCount.checked) {
+                                    console.log("Zero value- ignoring basket OK for FG count");
 
-                                return;
+                                    return;
+                                }
+                                NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.OK, btnEditBasket.checked);
+
+                                // If something's selected, set its value accordingly.
+                                var basket_id = modeSC.getBasketIdForCurrentRow();
+
+                                if (basket_id > 0) {
+                                    if (btnManualWeight.checked) {
+    //                                    if (stored_result > 0.0) {  // Zero is OK for FG
+                                            numpadEnteredWeight(basket_id, stored_result);
+    //                                    }
+
+                                    } else {
+                                        numpadEnteredCount(basket_id, stored_result);
+                                    }
+                                }
+
                             }
-                            NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.OK, btnEditBasket.checked);
 
-                            // If something's selected, set its value accordingly.
-                            var basket_id = modeSC.getBasketIdForCurrentRow();
-
-                            if (basket_id > 0) {
-                                if (btnManualWeight.checked) {
-//                                    if (stored_result > 0.0) {  // Zero is OK for FG
-                                        numpadEnteredWeight(basket_id, stored_result);
-//                                    }
-
-                                } else {
-                                    numpadEnteredCount(basket_id, stored_result);
+                            onClearnumpad: {
+                                // Added operation for CLR key iff:
+                                // 1. Entering a new basket (not editing an existing)
+                                // 2. Entering a weight (not a count)
+                                // 3. At least one digit has been entered (so a null basket has been entered).
+                                if (NBSM.isEnteringNewBasketWeight() &&
+                                        tvBaskets.currentRow == 0) {
+                                    console.debug("CLR btn while entering weight for new basket: new basket row removed.");
+                                    tvBaskets.removeCurrentBasket();
+                                    modeSC.reset();
                                 }
                             }
 
-                        }
-
-                        onClearnumpad: {
-                            // Added operation for CLR key iff:
-                            // 1. Entering a new basket (not editing an existing)
-                            // 2. Entering a weight (not a count)
-                            // 3. At least one digit has been entered (so a null basket has been entered).
-                            if (NBSM.isEnteringNewBasketWeight() &&
-                                    tvBaskets.currentRow == 0) {
-                                console.debug("CLR btn while entering weight for new basket: new basket row removed.");
-                                tvBaskets.removeCurrentBasket();
-                                modeSC.reset();
+                            function clearAndSelect() {
+                                numPad.clearnumpad();
+                                // Focus on the numPad's output textbox and select the "0" cleared amount.
+                                numPad.selectAll();
                             }
-                        }
 
-                        function clearAndSelect() {
-                            numPad.clearnumpad();
-                            // Focus on the numPad's output textbox and select the "0" cleared amount.
-                            numPad.selectAll();
-                        }
-
-                        function numpadEnteredWeight(basket_id, value) {
-                            if (value > 0.0 && !decimalPortionOfWeightIsOK(value)) {
-                                // FIELD-1423: Require that decimal portion of weight ends in .x0 or .x5
-                                console.debug("Decimal digits of weight " + value +
-                                        " don't end in .x0 or .x5.");
-                                dlgBasketWeightBadDecimalDigits.invalidWeight = value;
-                                dlgBasketWeightBadDecimalDigits.open();
-                            } else {
-                                // Typical - no error, no confirmation needed
-                                if (value === 0)
-                                    value = null;
-                                modeSC.addBasketWeight(basket_id, value);
-                                console.debug("Weight is OK without need for confirmation: '",
-                                    value, "'.");
-                            }
-                        }
-                        function numpadEnteredCount(basket_id, value) {
-                            console.debug("numPad Entered Count")
-                            dlgCounts.validate(basket_id, value)
-                        }
-                        ProtocolWarningDialog {
-                            // dlg wrapper for count value validations
-                            id: dlgCounts
-                            btnAckText: "Yes, count is correct"
-                            btnOKText: "No, return to entry"
-                            property int _count
-                            property int _basket
-
-                            function save() {
-                            // reusable save func
-                                if (_basket) {
-                                    modeSC.editBasketCount(_basket, _count)
-//                                    warnIfAvgWeightShowsAsZero();  // not needed in FG...
-                                    modeSC.reset()
+                            function numpadEnteredWeight(basket_id, value) {
+                                if (value > 0.0 && !decimalPortionOfWeightIsOK(value)) {
+                                    // FIELD-1423: Require that decimal portion of weight ends in .x0 or .x5
+                                    console.debug("Decimal digits of weight " + value +
+                                            " don't end in .x0 or .x5.");
+                                    dlgBasketWeightBadDecimalDigits.invalidWeight = value;
+                                    dlgBasketWeightBadDecimalDigits.open();
                                 } else {
-                                    console.debug("Basket id not set, unable to save count")
+                                    // Typical - no error, no confirmation needed
+                                    if (value === 0)
+                                        value = null;
+                                    modeSC.addBasketWeight(basket_id, value);
+                                    console.debug("Weight is OK without need for confirmation: '",
+                                        value, "'.");
                                 }
                             }
-                            function validate(basket_id, value) {
-                            // place to customize validations for yes/no dialogs
-                                _count = value
-                                _basket = basket_id
-                                // validations go here: open() and return for custom validations
-                                if (_count > 250) {  // FIELD-1224
-                                    dlgCounts.message = "Warning! Count is greater than expected.\nIs this count correct?"
-                                    dlgCounts.open()
-                                    return
-                                } else {
+                            function numpadEnteredCount(basket_id, value) {
+                                console.debug("numPad Entered Count")
+                                dlgCounts.validate(basket_id, value)
+                            }
+                            ProtocolWarningDialog {
+                                // dlg wrapper for count value validations
+                                id: dlgCounts
+                                btnAckText: "Yes, count is correct"
+                                btnOKText: "No, return to entry"
+                                property int _count
+                                property int _basket
+
+                                function save() {
+                                // reusable save func
+                                    if (_basket) {
+                                        modeSC.editBasketCount(_basket, _count)
+    //                                    warnIfAvgWeightShowsAsZero();  // not needed in FG...
+                                        modeSC.reset()
+                                    } else {
+                                        console.debug("Basket id not set, unable to save count")
+                                    }
+                                }
+                                function validate(basket_id, value) {
+                                // place to customize validations for yes/no dialogs
+                                    _count = value
+                                    _basket = basket_id
+                                    // validations go here: open() and return for custom validations
+                                    if (_count > 250) {  // FIELD-1224
+                                        dlgCounts.message = "Warning! Count is greater than expected.\nIs this count correct?"
+                                        dlgCounts.open()
+                                        return
+                                    } else {
+                                        dlgCounts.save()
+                                    }
+                                }
+                                onAccepted: { // select numpad txt field and set to 0
+                                    numPad.clearAndSelect()
+                                }
+                                onRejected: { // save basket count, reset
                                     dlgCounts.save()
                                 }
                             }
-                            onAccepted: { // select numpad txt field and set to 0
-                                numPad.clearAndSelect()
-                            }
-                            onRejected: { // save basket count, reset
-                                dlgCounts.save()
-                            }
-                        }
 
-                        function decimalPortionOfWeightIsOK(weight_string) {
-                            // FIELD-1423: Given a string with a float value with two decimal places,
-                            // return false if the second decimal digit is not 0 or 5.
-                            // TODO: Consider using regular expression. Current implementation
-                            // may be clearer, and it's only called on a numpad OK click.
-                            console.assert(typeof weight_string === 'string',
-                                    "Weight should be of type string.");
-                            console.assert(limitToTwoDecimalPlaces,
-                                'decimal place checking assuming two decimal digits');
+                            function decimalPortionOfWeightIsOK(weight_string) {
+                                // FIELD-1423: Given a string with a float value with two decimal places,
+                                // return false if the second decimal digit is not 0 or 5.
+                                // TODO: Consider using regular expression. Current implementation
+                                // may be clearer, and it's only called on a numpad OK click.
+                                console.assert(typeof weight_string === 'string',
+                                        "Weight should be of type string.");
+                                console.assert(limitToTwoDecimalPlaces,
+                                    'decimal place checking assuming two decimal digits');
 
-                            var decimalPtIdx = weight_string.indexOf('.');
-                            if (decimalPtIdx < 0) {
-                                // Weight has no decimal portion.
-                                return true;
-                            }
-                            var decimalDigits = weight_string.substring(decimalPtIdx+1);
-                            if (decimalDigits.length < 2) {
-                                // Weight has less than two decimal digits. A zero may be implied.
-                                return true;
-                            }
-                            if (decimalDigits.endsWith('0') || decimalDigits.endsWith('5')) {
-                                // Last of two decimal digits is either zero or five.
-                                return true;
-                            }
-                            // weight_string has two decimal places and does not end in 0 or 5.
-                            return false;
-                        }
-
-                        function containsAValue() {
-                            return (numPad.textNumPad.text &&
-                                    numPad.textNumPad.text.length > 0);
-                        }
-
-                        function isNonZero() {
-                            if (containsAValue()) {
-                                return parseFloat(numPad.textNumPad.text) > 0;
-                            } else {
+                                var decimalPtIdx = weight_string.indexOf('.');
+                                if (decimalPtIdx < 0) {
+                                    // Weight has no decimal portion.
+                                    return true;
+                                }
+                                var decimalDigits = weight_string.substring(decimalPtIdx+1);
+                                if (decimalDigits.length < 2) {
+                                    // Weight has less than two decimal digits. A zero may be implied.
+                                    return true;
+                                }
+                                if (decimalDigits.endsWith('0') || decimalDigits.endsWith('5')) {
+                                    // Last of two decimal digits is either zero or five.
+                                    return true;
+                                }
+                                // weight_string has two decimal places and does not end in 0 or 5.
                                 return false;
                             }
-                        }
 
-                        function decimalPointHasBeenEntered() {
-                            if (numPad.containsAValue() &&
-                                    numPad.textNumPad.text.indexOf(".") > -1) {
-                                return true;
-                            } else {
-                                return false;
+                            function containsAValue() {
+                                return (numPad.textNumPad.text &&
+                                        numPad.textNumPad.text.length > 0);
+                            }
+
+                            function isNonZero() {
+                                if (containsAValue()) {
+                                    return parseFloat(numPad.textNumPad.text) > 0;
+                                } else {
+                                    return false;
+                                }
+                            }
+
+                            function decimalPointHasBeenEntered() {
+                                if (numPad.containsAValue() &&
+                                        numPad.textNumPad.text.indexOf(".") > -1) {
+                                    return true;
+                                } else {
+                                    return false;
+                                }
+                            }
+
+                            onNumpadinput: {
+                                //console.debug("Stored numpad result is '" + numPad.textNumPad.text + "'.");
+                                if (!checkDRSet()) {
+                                    return;
+                                }
+
+                                if (!appstate.sets.isCalWeightSpecified) {
+                                    dlgNoWM.open();
+                                    clearnumpad();
+                                    return;
+                                }
+
+                                NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.DIGIT, btnEditBasket.checked);
+
+
+                                // Could be handling digit for weight, or for count
+                                if (tvBaskets.currentRow == -1) { // Handling first digit for weight
+                                    // If user starts inputting without row selected, create new basket
+                                    modeSC.addNewBasket(null, null);
+                                }
+                            }
+
+                            onNoWeightPressed: {
+                                if (!checkDRSet()) {
+                                    return;
+                                }
+
+                                if (tvBaskets.currentRow == -1) { // Handling first digit for weight
+                                    // If user starts inputting without row selected, create new basket
+                                    modeSC.addNewBasket(null, null);
+                                }
+                                var basket_id = modeSC.getBasketIdForCurrentRow();
+                                NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.DIGIT, btnEditBasket.checked);
+                                numpadEnteredWeight(basket_id, null);
+
+                                if (ObserverSettings.enableAudio) {
+                                   soundPlayer.play_sound("noCount", false)
+                                }
                             }
                         }
-
-                        onNumpadinput: {
-                            //console.debug("Stored numpad result is '" + numPad.textNumPad.text + "'.");
-                            if (!checkDRSet()) {
-                                return;
-                            }
-
-                            if (!appstate.sets.isCalWeightSpecified) {
-                                dlgNoWM.open();
-                                clearnumpad();
-                                return;
-                            }
-
-                            NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.DIGIT, btnEditBasket.checked);
-
-
-                            // Could be handling digit for weight, or for count
-                            if (tvBaskets.currentRow == -1) { // Handling first digit for weight
-                                // If user starts inputting without row selected, create new basket
-                                modeSC.addNewBasket(null, null);
-                            }
-                        }
-
-                        onNoWeightPressed: {
-                            if (!checkDRSet()) {
-                                return;
-                            }
-
-                            if (tvBaskets.currentRow == -1) { // Handling first digit for weight
-                                // If user starts inputting without row selected, create new basket
-                                modeSC.addNewBasket(null, null);
-                            }
-                            var basket_id = modeSC.getBasketIdForCurrentRow();
-                            NBSM.handleNewBasketEvent(NBSM.NEW_BASKET_EVENT.DIGIT, btnEditBasket.checked);
-                            numpadEnteredWeight(basket_id, null);
-
-                            if (ObserverSettings.enableAudio) {
-                               soundPlayer.play_sound("noCount", false)
+                        ObserverWeightMatrix { // FIELD-1698: Allow matrix weight selection
+                            id: wtMatrix
+                            y: 73
+                            x: 2
+                            enable_audio: true
+                            onWeightClicked: {
+                                if (!gridDR.is_dr_set() && !appstate.catches.species.isRetained && !is_mix) {  // FIELD-2028
+                                        dlgSelectDRWarning.open();
+                                        return;
+                                    }
+                                modeSC.addNewBasket(weight, 1)  // matrix weight always has count of 1
+                                warnIfAvgWeightShowsAsZero();
+                                modeSC.selectNewestRow()  // select newly added wt
                             }
                         }
                     }
@@ -898,6 +936,9 @@ Item {
             }
 
             onCurrentRowChanged: {
+                if (btnMatrixWeight.checked) {
+                    return  // don't do any of the stuff below if using weight matrix
+                }
                 // console.debug("currentRow='" + currentRow + "'.");
                 if (currentRow != -1 && currentRow < model.count) {
                     // Either: (1) a row was clicked: -> go into edit mode of existing basket
@@ -911,9 +952,11 @@ Item {
                     if (NBSM.isEnteringNewBasket()) {
                         btnEditBasket.checked = false;
                         btnManualCount.enabled = false; // Require OK'd weight before moving to count
+                        btnMatrixWeight.enabled = false;  // no switching to matrix mid-basket
                         basketEntryStatusMessage.update(NBSM.msgNBWIP);
                     } else if (btnEditBasket.checked) {
                         btnManualCount.enabled = true;
+                        btnMatrixWeight.enabled = false;  // no editing w matrix
                         basketEntryStatusMessage.update(NBSM.msgStartEditingExistingBasket);
                     }
                 }

--- a/qml/observer/ObserverWeightMatrix.qml
+++ b/qml/observer/ObserverWeightMatrix.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.5
+import QtQuick.Layouts 1.2
+import QtQuick.Controls 1.3
+import QtQuick.Controls.Styles 1.3
+import QtQuick.Window 2.2
+import QtQuick.Extras 1.4
+
+// Custom Model
+import "../common"
+import "."
+
+Item {
+    id: wtMatrix
+    property real lowerRange: 0.25  // adjust these if range adjustment needed
+    property real upperRange: 21
+    property real step: 0.25
+    property bool enable_audio: false
+
+    signal weightClicked(real weight)
+
+    function createModel() {
+        var arr = []
+        for (var i = wtMatrix.lowerRange; i <= wtMatrix.upperRange; i += wtMatrix.step) {
+            arr.push(i)
+        }
+        return arr
+    }
+
+    ScrollView   {
+        id: sv
+        width: (ScreenUnits.numPadButtonSize * 4) + (gridMatrix.columnSpacing * 4) + 20
+        height: (ScreenUnits.numPadButtonSize * 5) + (gridMatrix.rowSpacing * 5)
+        clip: true
+        GridLayout {
+            id: gridMatrix
+//            anchors.fill: parent
+            columnSpacing: 6
+            rowSpacing: 6
+            columns: 4
+            rows: (wtMatrix.upperRange - wtMatrix.lowerRange) / gridMatrix.columns
+            Repeater {
+                id: rptMatrixBtns
+                model: wtMatrix.createModel()
+                FramNumPadButton {
+                    text: modelData.toFixed(2)
+                    Layout.preferredWidth: ScreenUnits.numPadButtonSize
+                    Layout.preferredHeight: ScreenUnits.numPadButtonSize
+                    onClicked: {
+                        console.info("Weight clicked is " + modelData.toFixed(2))
+                        weightClicked(modelData.toFixed(2))
+                        if (enable_audio) {
+                            soundPlayer.play_sound("matrixWtSel", false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/observer/ObserverWeightMatrix.qml
+++ b/qml/observer/ObserverWeightMatrix.qml
@@ -11,6 +11,9 @@ import "."
 
 Item {
     id: wtMatrix
+    property alias step: wtMatrix.step
+    property alias lowerRange: wtMatrix.lowerRange
+    property alias upperRange: wtMatrix.upperRange
     property real lowerRange: 0.25  // adjust these if range adjustment needed
     property real upperRange: 21
     property real step: 0.25
@@ -25,15 +28,12 @@ Item {
         }
         return arr
     }
-
     ScrollView   {
         id: sv
         width: (ScreenUnits.numPadButtonSize * 4) + (gridMatrix.columnSpacing * 4) + 20
         height: (ScreenUnits.numPadButtonSize * 5) + (gridMatrix.rowSpacing * 5)
-        clip: true
         GridLayout {
             id: gridMatrix
-//            anchors.fill: parent
             columnSpacing: 6
             rowSpacing: 6
             columns: 4

--- a/qml/observer/codebehind/CountsWeightsNewBasketSM.js
+++ b/qml/observer/codebehind/CountsWeightsNewBasketSM.js
@@ -18,12 +18,14 @@ var msgNBWIP = "New basket weight:\nEnter digit, decimal pt, or OK";
 var msgNBWIP_DECPT_DONE = "New basket weight:\nEnter digit, or OK";
 var msgRFNBC = "New basket count:\nEnter digit or No Count";
 var msgNBCIP = "New basket count:\nEnter digit, No Count, or OK";
+var msgRFMBW = "New matrix basket:\nSelect weight from matrix"
 
 var NEW_BASKET_STATE = {
     RFNBW: {value: 0, name: "ReadyForNewBasketWeight"},
     NBWIP: {value: 1, name: "NewBasketWeightInProgress"},
     RFNBC: {value: 2, name: "ReadyForNewBasketCount"},
-    NBCIP: {value: 3, name: "NewBasketCountInProgress"}
+    NBCIP: {value: 3, name: "NewBasketCountInProgress"},
+    RFMBW: {value: 4, name: "ReadyForMatrixBasketWeight"}
 };
 var curNewBasketState = NEW_BASKET_STATE.RFNBW;
 
@@ -33,8 +35,14 @@ var NEW_BASKET_EVENT = {
     DELETE_CONFIRMED: {value: 1, name: "DeleteConfirmed"},
     OK: {value: 2, name: "OKPressed"},
     MANUAL_WEIGHT: {value: 3, name: "ManualWeightButton"},
-    NO_COUNT: {value: 4, name: "NoCountButton"}
+    NO_COUNT: {value: 4, name: "NoCountButton"},
+    MATRIX_WEIGHT: {value: 5, name: "MatrixWeight"}  // not currently being used, but added per FIELD-1698
 };
+
+function isEnteringMatrixBasket() {
+    curNewBasketState = NEW_BASKET_STATE.RFMBW
+    updateBasketStatusMessage(msgRFMBW)
+}
 
 function resetNewBasketState() {
     //console.trace();

--- a/qrc/observer.qrc
+++ b/qrc/observer.qrc
@@ -84,6 +84,7 @@
         <file>../qml/observer/ObserverLogin.qml</file>
         <file>../qml/observer/ObserverNumPad.qml</file>
         <file>../qml/observer/ObserverNumPadDialog.qml</file>
+        <file>../qml/observer/ObserverWeightMatrix.qml</file>
         <file>../qml/observer/ObserverProgramPickerDialog.qml</file>
         <file>../qml/observer/ObserverSettings.qml</file>
         <file>../qml/observer/ObserverSunlightButton.qml</file>


### PR DESCRIPTION
See https://www.fisheries.noaa.gov/jira/browse/FIELD-1698

1. Created ObserverWeightMatrix.qml object for import
2. Created StackLayout to toggle numpad vs matrix
3. Added button to allow toggle of stacklayout and setup matrix for use
4. Changes to CountsWeightsNewBasketSM are mostly housekeeping for now

Matrix weights should select when entered and always have count of 1.  Users can edit these baskets, but not while in Matrix mode.