### PR TITLE
FIELD-1697: Length-only Biospecimen Matrix

### DIFF
--- a/py/observer/Hauls.py
+++ b/py/observer/Hauls.py
@@ -495,6 +495,10 @@ class Hauls(QObject):
 
         return False
 
+    @pyqtProperty(bool, notify=unusedSignal)
+    def isShrimpGear(self):
+        return self.getData('gear_type') in ['12', '13']
+
     @pyqtSlot(QVariant, result=QVariant, name='getObserverRetModel')
     def getObserverRetModel(self, haul_db_id):
         """

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -1167,7 +1167,6 @@ class ObserverCatches(QObject):
 
         if wm == '14' and self.currentSampleMethodIsNoSpeciesComposition and self._is_fixed_gear:
             sw = self.getData('sample_weight')
-            print('sw is: ', sw)
             # have to check sw for undefined, None, or nan values
             if not sw or sw is None or (sw != sw):
                 self._logger.info(f"WM 14 but now sample weight, no CC complete")

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.2+31"
+optecs_version = "2.1.2+37"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverSoundPlayer.py
+++ b/py/observer/ObserverSoundPlayer.py
@@ -138,6 +138,7 @@ class SoundPlayer(QObject):
                   'numpadBack': 'resources/sounds/minimal-ui-sounds/click3.wav',
                   'numpadOK': 'resources/sounds/minimal-ui-sounds/beep.mp3',
                   'matrixWtSel': 'resources/sounds/minimal-ui-sounds/beep.mp3',
+                  'matrixSel': 'resources/sounds/minimal-ui-sounds/beep.mp3',
                   'keyOK': 'resources/sounds/minimal-ui-sounds/beep.mp3',
                   'click': 'resources/sounds/minimal-ui-sounds/click2.wav',
                   'saveRecord': 'resources/sounds/minimal-ui-sounds/funnyclick.wav',

--- a/py/observer/ObserverSpecies.py
+++ b/py/observer/ObserverSpecies.py
@@ -279,6 +279,7 @@ class ObserverSpecies(QObject):
         self.otag_protocols = {'OT', 'T'}  # Observer Tag. 'T' is deprecated - use 'OT' instead.
         self.tag_protocols = self.etag_protocols.union(self.otag_protocols)
         self.barcode_protocols = {'WS', 'FC', 'FR', 'O', 'SS', 'SC', 'TS'}
+        self.length_only_protocols = {'FL', 'CL', 'AL', 'TL', 'VL', 'CW', 'W'}  # removed "-" from list
 
         # Helper class with Weight Method 3
         self._observer_catches = observer_catches
@@ -1406,6 +1407,18 @@ class ObserverSpecies(QObject):
     def requiredProtocolsBarcodes(self):
         return list(self.barcode_protocols & self.current_protocol_set) \
             if self.barcode_protocols and self.current_protocol_set else None
+
+    @pyqtProperty(bool, notify=currentProtocolsChanged)
+    def isLengthOnlyProtocols(self):
+        """
+        if protocol that requires something other than length exists, return false, else true
+        :return: boolean
+        """
+        if self.current_protocol_set:
+            return len(self.length_only_protocols | self.current_protocol_set) <= len(self.length_only_protocols)
+        else:
+            return False
+
 
     # Biospecies Items boolean flags automatically set via lookup_protocols_by_species_name
     @pyqtProperty(bool, notify=currentProtocolsChanged)

--- a/qml/observer/BiospecimensScreen.qml
+++ b/qml/observer/BiospecimensScreen.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import QtQuick.Layouts 1.2
 import QtQuick.Controls.Private 1.0
+import QtQuick.Dialogs 1.2
 
 import "../common"
 import "."
@@ -39,6 +40,12 @@ ColumnLayout {
         tvBioEntries.selection.clear();
         tvBioEntries.currentRow = 0;
         tvBioEntries.selection.select(tvBioEntries.currentRow);
+    }
+
+    function unselect() {
+        // deselect all in tv model
+        tvBioEntries.selection.clear()
+        tvBioEntries.currentRow = -1
     }
 
     function set_biospecimen_species_from_catch_category() {
@@ -571,11 +578,110 @@ ColumnLayout {
                     Layout.preferredWidth: 30
                 }
                 ObserverSunlightButton {
+                    // button trigger for length matrix
+                    id: btnLengthMtx
+                    text: "Length\nMatrix"
+                    Layout.preferredWidth: 100
+                    Layout.preferredHeight: 50
+                    // hide if modify button checked, isPHLB and not BSM 10, or something other than length required
+                    visible: (!bModifyEntry.checked && ((appstate.catches.isPHLB && rowBiosample.currentBM == '10') || (appstate.catches.species.isLengthOnlyProtocols)))
+                    onClicked: {
+                        if(!labelBSMethodDesc.is_selected()) {
+                            dlgSelectBMWarning.open()
+                        } else { // set phlb or non-phlb models
+                            if (appstate.catches.isPHLB) {
+                                mtx.setModel(10)
+                            } else {
+                                mtx.setModel(1)
+                            }
+                            dlgLengthMatrix.open()
+                        }
+                    }
+                    Dialog {
+                        id: dlgLengthMatrix
+                        title: 'BS Length Matrix'
+                        width: mtx.matrixWidth + 70
+                        height: mtx.matrixHeight + 70
+                        property bool opened: false  // used to fake onClosed signal
+                        signal dlgClosed  // used to fake onClosed signal
+                        signal dlgOpened  // used to fake onClosed signal
+                        contentItem: Rectangle {
+                            anchors.margins: 20
+                            anchors.fill: parent
+                            color: "#eee"
+                            RowLayout {
+                                id: rlMtx
+                                FramLabel {
+                                    id: lblMtx
+                                    text: "Select a biospecimen length (cm):"
+                                    font.pixelSize: 20
+                                    Layout.preferredHeight: 40
+                                }
+                                ObserverMatrix {
+                                    id: mtx
+                                    anchors.top: lblMtx.bottom
+                                    enable_audio: true
+                                    lowerRange: 1
+                                    upperRange: 250
+                                    increment: 1
+                                    columns: 5
+                                    buttonHeight: 50
+                                    precision: 0
+                                    onValClicked: {
+                                        // TODO: option to save or retract low or high bs length
+                                        if (val < 10 && !appstate.catches.isPHLB && !appstate.hauls.isShrimpGear) {
+                                            dlgLengthWarning.display("Warning! Low length value selected:\n\n" + val + "cm < 10")
+                                        } else if (val > 100 && !appstate.catches.isPHLB) {
+                                            dlgLengthWarning.display("Warning! High length value selected:\n\n" + val + "cm > 100")
+                                        }
+                                        appstate.catches.biospecimens.addBiospecimenItem(
+                                            tfSpecies.text,
+                                            rowBiosample.currentBM,
+                                            null
+                                        );
+                                        appstate.catches.biospecimens.setData('specimen_length', val)
+                                        screenBio.selectNewestRow()
+                                    }
+                                    FramNoteDialog {
+                                        id: dlgLengthWarning
+                                        title: "Length Warning"
+                                        bkgcolor: "#FA8072"
+                                        height: 250
+                                        message: ""
+                                        function display(msg) {
+                                            message = msg
+                                            dlgLengthWarning.open()
+                                        }
+                                    }
+                                    Component.onCompleted: {
+                                        mtx.addModel(10, 10, 249) // custom PHLB model
+                                    }
+                                }
+                            }
+                        }
+                        // not sure why onClosed doesnt work for Dialog, but this mess below does
+                        onVisibleChanged : {
+                            if (!this.visible) {
+                                dlgClosed()
+                            } else {
+                                dlgOpened()
+                            }
+                        }
+                        onDlgClosed: {
+                            opened = false
+                            screenBio.unselect()
+                        }
+                        onDlgOpened: {
+                            opened = true
+                        }
+                    }
+                }
+                ObserverSunlightButton {
                     id: bSaveEntry
                     text: "Save\nEntry"
                     Layout.preferredWidth: 150
                     Layout.preferredHeight: 50
-                    enabled: labelBSMethodDesc.is_selected() && tvBioEntries.currentRow >= 0
+                    enabled: labelBSMethodDesc.is_selected() && tvBioEntries.currentRow >= 0 && !dlgLengthMatrix.opened
                     txtBold: true
                     highlightColor: "lightgreen"
 
@@ -585,10 +691,7 @@ ColumnLayout {
                             dlgMissingProtocols.showNeeded();
                         // check for length less then 10 for non-shrimp trips (not gear type 12 or 13)
                         } else if ((appstate.catches.biospecimens.getData('specimen_length') < 10) &&
-                                   !((appstate.hauls.getData('gear_type') == '12') ||
-                                     (appstate.hauls.getData('gear_type') == '13') ||
-                                     (appstate.sets.getData('gear_type') == '12') ||
-                                     (appstate.sets.getData('gear_type') == '13'))) {
+                                   !(appstate.hauls.isShrimpGear)) {
                             slw_screen.trigger_sm_len_warning();
                         } else if ((appstate.catches.isPHLB) || (appstate.catches.biospecimens.getData('specimen_length') < 100)) {
                             save_biospecimen_entry();

--- a/qml/observer/ObserverMatrix.qml
+++ b/qml/observer/ObserverMatrix.qml
@@ -1,0 +1,103 @@
+import QtQuick 2.5
+import QtQuick.Layouts 1.2
+import QtQuick.Controls 1.3
+import QtQuick.Controls.Styles 1.3
+import QtQuick.Window 2.2
+import QtQuick.Extras 1.4
+
+// Custom Model
+import "../common"
+import "."
+
+Item {
+    id: matrix
+    property bool enable_audio: false
+    property real increment: 0.25
+    property real lowerRange: 0.25
+    property real upperRange: 40.0
+    property int precision: 2  // allows adjustment of level of precision (e.g. 2.00 (2) vs 2 (0))
+    property int buttonWidth: ScreenUnits.numPadButtonSize
+    property int buttonHeight: ScreenUnits.numPadButtonSize
+    property int columns: 4
+    property int visibleRows: 5
+    property var storedModels // store models to speed things up, rather than create on the fly
+    property alias currentModel: rptMatrixBtns.model
+    property alias matrixWidth: sv.width
+    property alias matrixHeight: sv.height
+
+    signal valClicked(real val)  // signal passes value stripped from button
+
+    Component.onCompleted: {
+    // load up default model from parameters defined above
+        storedModels = {}
+        matrix.addModel(increment, lowerRange, upperRange)  // add default model
+        matrix.setModel(increment)  // set default model
+    }
+
+    function setModel(incr) {
+    // use for toggling model in matrix
+        if (storedModels[incr]) {
+            matrix.increment = incr
+            rptMatrixBtns.model = storedModels[incr]
+            console.info("Matrix model incremented by " + incr)
+        } else {
+            console.info("Increment model " + incr + " has not been created yet!  Please use 'addModel' func")
+        }
+    }
+    function addModel(incr, lr, ur) {
+        // incase you wanted to add custom model, or overwrite existing
+        storedModels[incr] = matrix.createModel(incr, lr, ur)
+        console.debug("New matrix model stored: increment=" + increment + ", " + lr + " - " + ur)
+    }
+
+    function createModel(incr, lr, ur) {
+        // loop, step, and push (better way to do this??)
+        var arr = []
+        for (var i = lr; i <= ur; i+= incr) {
+            arr.push(i)
+        }
+        return arr
+    }
+
+    ScrollView   {
+        // TODO: Make this scalable/flexible with window movements
+        // TODO: function to customize button colors within a range?
+        id: sv
+        width: (ScreenUnits.numPadButtonSize * matrix.columns) + (gridMatrix.columnSpacing * matrix.columns) + 20
+        height: (ScreenUnits.numPadButtonSize * matrix.visibleRows) + (gridMatrix.rowSpacing * matrix.visibleRows)
+        GridLayout {
+            id: gridMatrix
+            flow: GridLayout.LeftToRight
+            columnSpacing: 6
+            rowSpacing: 6
+            columns: matrix.columns
+            Repeater {
+                id: rptMatrixBtns
+                Button {
+                    id: mtxBtn
+                    Layout.preferredWidth: matrix.buttonWidth
+                    Layout.preferredHeight: matrix.buttonHeight
+                    style: ButtonStyle {
+                        label: Component {
+                            Text {
+                                renderType: Text.NativeRendering
+                                verticalAlignment: Text.AlignVCenter
+                                horizontalAlignment: Text.AlignHCenter
+                                font.family: "Helvetica"
+                                font.pixelSize: ScreenUnits.numPadButtonTextHeight
+                                text: modelData.toFixed(matrix.precision)
+                            }
+                        }
+                    }
+                    onClicked: {
+                        console.info("Matrix value clicked: " + modelData.toFixed(matrix.precision))
+                        valClicked(modelData.toFixed(matrix.precision))
+                        if (enable_audio) {
+                            soundPlayer.play_sound("matrixSel", false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/observer/ObserverWeightMatrix.qml
+++ b/qml/observer/ObserverWeightMatrix.qml
@@ -9,6 +9,8 @@ import QtQuick.Extras 1.4
 import "../common"
 import "."
 
+// TODO: Use ObserverMatrix instead of this in CountsWeights matrix
+
 Item {
     id: wtMatrix
     // set default values

--- a/qrc/observer.qrc
+++ b/qrc/observer.qrc
@@ -85,6 +85,7 @@
         <file>../qml/observer/ObserverNumPad.qml</file>
         <file>../qml/observer/ObserverNumPadDialog.qml</file>
         <file>../qml/observer/ObserverWeightMatrix.qml</file>
+        <file>../qml/observer/ObserverMatrix.qml</file>
         <file>../qml/observer/ObserverProgramPickerDialog.qml</file>
         <file>../qml/observer/ObserverSettings.qml</file>
         <file>../qml/observer/ObserverSunlightButton.qml</file>


### PR DESCRIPTION
See https://www.fisheries.noaa.gov/jira/browse/FIELD-1697

Whats changed:
1. ObserverMatrix.qml created, scrollView with grid of buttons
2. Create button to launch matrix window in BiospecimensScreen; btn mvisible if length-only protocol, or phlb and BSM 10 (and modify button not selected)
3. Allow matrix window to insert length-only biospecimens to tableview, unselecting all when window closed
4. Show basic warnings if small or large lengths are selected

Also created isShrimpGear property in hauls, and replaced some logic to use this feature.  species.isLengthOnlyProtocols is also new and used for matrix enabling.