### PR TITLE
Resolving old library dependabot issues

### DIFF
--- a/doc/dev_env/requirements.pip.txt
+++ b/doc/dev_env/requirements.pip.txt
@@ -3,5 +3,5 @@
 future==0.15.2
 peewee==2.8.5
 pefile==2016.3.28
-PyInstaller==3.2
+PyInstaller==3.6
 pypiwin32==219

--- a/doc/dev_env/requirements.virtualenv.python36.txt
+++ b/doc/dev_env/requirements.virtualenv.python36.txt
@@ -16,7 +16,7 @@ PyQt5==5.7.1
 python-dateutil==2.6.0
 pytz==2016.10
 pywin32-ctypes==0.0.1
-requests==2.13.0
+requests==2.20.0
 requests-toolbelt==0.7.0
 sip==4.19
 six==1.10.0


### PR DESCRIPTION
dependabot is picking up issues with libraries in the doc/ directory.  Updating requests isn't an issue, software is already using package version 2.20.0.  PyInstaller is still implemented in the GitLab repo, and using 3.6 shouldn't be an issue.  The field-software is also not created using the onefile arg.