### PR TITLE
New feature to perform auto-calc of Dropoff/Predated fish weights

### DIFF
--- a/build/build_observer.py
+++ b/build/build_observer.py
@@ -245,7 +245,7 @@ excludes = []
 packages = ['os', 'apsw', 'peewee', 'playhouse', 'fractions',
             'dateutil', 'encodings', 'arrow', 'idna',
             'logging', 'keyring', 'lxml', 'socket',
-            'sqlparse', 'typing', 'zeep', 'filecmp', 'asyncio', 'pygame', 'idna']
+            'sqlparse', 'typing', 'zeep', 'filecmp', 'asyncio', 'pygame', 'idna', 'geopy']
 path = []
 
 # Dependencies are automatically detected, but it might need fine tuning.

--- a/main_observer.py
+++ b/main_observer.py
@@ -46,6 +46,7 @@ from py.observer.SampleMethod import SampleMethod
 from py.observer.DiscardReason import DiscardReason
 from py.observer.CatchCategory import CatchCategory
 from py.observer.ObserverDBMigrations import ObserverDBMigrations
+from py.observer.ObserverDBCustomFuncs import ObserverDBCustomFuncs
 
 PROFILE_CODE = False
 
@@ -182,6 +183,7 @@ if __name__ == '__main__' or __name__ == 'observer__main__':
     migrator.perform_migrations()
 
     connect_orm()  # ObserverORM
+    ObserverDBCustomFuncs().register_funcs()
 
     main_qml = QUrl('qrc:/qml/observer/ObserverLogin.qml')
     appGuid = '8284d07e-d07c-4aad-8874-36720e37ce53'

--- a/py/observer/ObserverAutoComplete.py
+++ b/py/observer/ObserverAutoComplete.py
@@ -218,9 +218,9 @@ class ObserverAutoComplete(QObject):
                     (do_full_search and sug.lower().find(partial_str_lc) > 0)
         ]
 
-        if self._current_loaded_data == ACDataTypes.captains \
-                and len(self._suggestions) == 0 and len(partial_str) == 0:
-            self._suggestions.append('No skipper is associated with vessel.\nPlease add name in comments\nand contact Neil Riley to add to DB.')
+        if self._current_loaded_data == ACDataTypes.captains:
+            self._suggestions.append('"Not Listed"')  # FIELD-2076: give user option (doesn't actually do anything)
+
         self._logger.debug('Suggestion count: ' + str(len(self._suggestions)))
 
     @staticmethod

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -331,39 +331,6 @@ class ObserverCatches(QObject):
             self._logger.warning(fmt_str.format(catchcat_common_name))
             return None
 
-    @staticmethod
-    def get_species_complex(cc_id):
-        """
-        Return list of species ids related to catch category
-        Match species on 1.) catch category ID in many-to-many SpeciesCatchCategories table
-        2.) catch category name == species common name in Species table
-        3.) catch category code == species pacfin code in Species table
-        Static method so classes above (Sets) can use this in calculations
-        :param cc_id: Catch Category DB ID
-        :return: list (empty list if nothing found)
-        """
-        try:
-            cc = CatchCategories.get(CatchCategories.catch_category == cc_id)
-        except CatchCategories.DoesNotExist as e:
-            return []
-
-        # get linked species via SpeciesCatchCategories
-        spcc = SpeciesCatchCategories.select(
-            SpeciesCatchCategories.species
-        ).where(
-            SpeciesCatchCategories.catch_category == cc_id
-        )
-
-        # get species matched on pacfin code / catch category code
-        spp = Species.select(
-            Species.species
-        ).where(
-            (fn.Lower(Species.common_name) == cc.catch_category_name.lower()) |
-            (Species.pacfin_code == cc.catch_category_code)
-        )
-
-        return [s.species.species for s in spcc | spp]
-
     @pyqtProperty(QVariant, notify=catchIdChanged)
     def currentCatchCatCode(self):
         if self._current_catch:

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -390,8 +390,8 @@ class ObserverCatches(QObject):
                 self._current_catch.sample_count = None
             if self._current_catch.sample_weight == 0 or (self._current_catch.sample_weight != self._current_catch.sample_weight):
                 self._current_catch.sample_weight = None
-            # something is setting catch count to nan, which fails the save
-            if self._current_catch.catch_count != self._current_catch.catch_count:
+            # prevent catch_count = nan, catch_count = 0 (FIELD-2103: CHK_CATCH_COUNT_VAL prevents 0)
+            if self._current_catch.catch_count == 0 or (self._current_catch.catch_count != self._current_catch.catch_count):
                 self._current_catch.catch_count = None
             self._current_catch.save()
 

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -331,6 +331,39 @@ class ObserverCatches(QObject):
             self._logger.warning(fmt_str.format(catchcat_common_name))
             return None
 
+    @staticmethod
+    def get_species_complex(cc_id):
+        """
+        Return list of species ids related to catch category
+        Match species on 1.) catch category ID in many-to-many SpeciesCatchCategories table
+        2.) catch category name == species common name in Species table
+        3.) catch category code == species pacfin code in Species table
+        Static method so classes above (Sets) can use this in calculations
+        :param cc_id: Catch Category DB ID
+        :return: list (empty list if nothing found)
+        """
+        try:
+            cc = CatchCategories.get(CatchCategories.catch_category == cc_id)
+        except CatchCategories.DoesNotExist as e:
+            return []
+
+        # get linked species via SpeciesCatchCategories
+        spcc = SpeciesCatchCategories.select(
+            SpeciesCatchCategories.species
+        ).where(
+            SpeciesCatchCategories.catch_category == cc_id
+        )
+
+        # get species matched on pacfin code / catch category code
+        spp = Species.select(
+            Species.species
+        ).where(
+            (fn.Lower(Species.common_name) == cc.catch_category_name.lower()) |
+            (Species.pacfin_code == cc.catch_category_code)
+        )
+
+        return [s.species.species for s in spcc | spp]
+
     @pyqtProperty(QVariant, notify=catchIdChanged)
     def currentCatchCatCode(self):
         if self._current_catch:

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+0"
+optecs_version = "2.1.3+1"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBCustomFuncs.py
+++ b/py/observer/ObserverDBCustomFuncs.py
@@ -1,0 +1,143 @@
+"""
+-----------------------------------------------------------------------------
+Name:        ObserverDBCustomFuncs.py
+Purpose:     Load custom functions into SQLite db ORM
+
+Author:      Jim Fellows <james.fellows@noaa.gov>
+Created:     Sept. 10th 2020
+
+To add new function, add static method to ObserverDBCustomFuncs
+with _udf appended to method name.  Idea is to write equivalent functions
+in Oracle's OBSPROD schema, so that two functions with the same name
+can run logic specific to their environment, and produce the same result, for TER purposes
+
+https://www.fisheries.noaa.gov/jira/browse/FIELD-2093
+------------------------------------------------------------------------------
+"""
+
+import logging
+import arrow
+import inspect
+from py.observer.ObserverDBBaseModel import database
+from py.observer.ObserverDBUtil import ObserverDBUtil
+
+SQLITE_DATE_STR = ObserverDBUtil().default_dateformat  # current format being inserted to SQLite, used below
+
+
+class ObserverDBCustomFuncs:
+    """
+    Class used to organize methods together
+    No init setup at this time
+    """
+    def __init__(self):
+        pass
+
+    def register_funcs(self):
+        """
+        loop through _udf methods and register to db
+        :return: None
+        """
+        log_list = []
+        for m in self.get_funcs_to_register():
+            name = m.replace('_udf', '')
+            method_obj = getattr(self, m)
+            param_ct = self.get_param_count(method_obj)
+            database.register_function(method_obj, name, num_params=param_ct)
+            log_list.append(name)
+        logging.info(f'The following custom SQL functions are loaded: {str(log_list)}')
+
+    def get_funcs_to_register(self):
+        """
+        loop through class methods with 'udf' in name
+        :return: str[]
+        """
+        return [f for f in dir(self) if 'udf' in f]
+
+    @staticmethod
+    def get_param_count(method):
+        """
+        pass method/func, use inspect.signature to count func params
+        :param method: method/function
+        :return: int
+        """
+        return len(inspect.signature(method).parameters)
+
+    @staticmethod
+    def optecs_get_unixtime_udf(date_str):
+        """
+        Takes optecs date str and converts it to seconds since
+        1970 (unix time).
+        Mirrors OBSPROD.OPTECS_GET_SECONDS func
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: int
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).timestamp
+
+    @staticmethod
+    def optecs_get_year_udf(date_str):
+        """
+        Extract year int from optecs datestr
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: int (YYYY)
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).year
+
+    @staticmethod
+    def optecs_get_month_udf(date_str):
+        """
+        Extract month int from optecs datestr
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: int (MM)
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).month
+
+    @staticmethod
+    def optecs_get_day_udf(date_str):
+        """
+        Extract day int from optecs datestr
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: int (DD)
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).day
+
+    @staticmethod
+    def optecs_get_hour_udf(date_str):
+        """
+        Extract hour int from optecs datestr
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: int (HR24)
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).hour
+
+    @staticmethod
+    def optecs_parse_date_udf(date_str):
+        """
+        Takes optecs date str and converts it to a format
+        that SQLite can recognize as a date
+        Mirors function OBSPROD.OPTECS_PARSE_DATE
+        :param date_str: str with format 'MM/DD/YYYY HH:mm' (see ObserverDBUtil)
+        :return: str with format 'YYYY-MM-DD HH:mm' (see https://sqlite.org/lang_datefunc.html)
+        """
+        return arrow.get(date_str, SQLITE_DATE_STR).format('YYYY-MM-DD HH:mm')
+
+    @staticmethod
+    def reformat_date_str_udf(date_str, old_format, new_format):
+        """
+        allows conversion from one date str to another
+        :param date_str: str of date
+        :param old_format: format of date_str
+        :param new_format: new format e.g YYYY-MM-DD HH:mm
+        :return: reformatted date str
+        """
+        return arrow.get(date_str, old_format).format(new_format)
+
+
+# if __name__ == '__main__':
+#     ocf = ObserverDBCustomFuncs()
+#     # test_date_str = '12/30/2019 09:08'
+#     # print(type(arrow.get(test_date_str, 'MM/DD/YYYY HH:mm').format('YYYY-MM-DD HH:mm')))
+#     ocf.register_funcs()
+#     result = database.execute_sql("select get_iso_date_str('12/30/2019 09:08')")
+#     for r in result:
+#         print(r)
+#     # print(len(inspect.signature(ocf.add_one_udf).parameters))

--- a/py/observer/ObserverDBSyncController.py
+++ b/py/observer/ObserverDBSyncController.py
@@ -457,7 +457,7 @@ class ObserverDBSyncController(QObject):
                 # "EVALUATION_ID", "PARTIAL_TRIP", "SKIPPER_ID", "FISHERY", "CREW_SIZE",
                 None, None, row.logbook_type, first_receiver,  # TODO: PERMIT_NUMBER, LICENSE_NUMBER
                 # "PERMIT_NUMBER", "LICENSE_NUMBER", "LOGBOOK_TYPE", "FIRST_RECEIVER",
-                None, None, None, None, ObserverDBUtil.get_data_source(),
+                None, None, None, None, row.data_source,
                 # "EXPORT", "EXTERNAL_TRIP_ID", "DO_EXPAND", "RUN_TER", "DATA_SOURCE",
                 None, None, row.fish_processed, None,
                 # "ROW_PROCESSED", "ROW_STATUS", "FISH_PROCESSED", "NO_FISHING_ACTIVITY",

--- a/py/observer/ObserverSpecies.py
+++ b/py/observer/ObserverSpecies.py
@@ -240,7 +240,7 @@ class ObserverSpecies(QObject):
 
         self._species_comp_items_model = ObserverSpeciesCompModel()
 
-        self._counts_weights = CountsWeights()
+        self._counts_weights = CountsWeights(self)
         self._filter_name = ''  # Filter both by common_name and by scientific_name
 
         self.current_protocol_str = ''  # store protocol lookup, e.g. 'FL, WS'
@@ -1506,6 +1506,36 @@ class ObserverSpecies(QObject):
     @pyqtProperty(QVariant, notify=totalCatchCountChanged)
     def totalCatchCount(self):
         return self._total_haul_count
+
+    @staticmethod
+    def get_related_species(species_id):
+        """
+        If species is one of a few where multiple need to be compared,
+        return a list of related species, else return that species only
+        :param species_id: species DB id (int)
+        :return: int[]
+        """
+        complexes = {
+            'thornyhead': [
+                10239,  # longspine
+                10492,  # shortspine / longspine
+                10491  # shortspine
+            ],
+            'shortraker': [
+                10254,  # shortraker
+                10427,  # shortraker/rougheye/blackspotted
+                10490  # rougheye/blackspotted
+            ],
+            'skate': [
+                10334,  # big skate
+                10337,  # longnose skate
+                10338  # sandpaper skate
+            ]
+        }
+        for species in complexes.values():
+            if species_id in species:
+                return species
+        return [species_id]
 
 
 class TestObserverSpecies(unittest.TestCase):

--- a/py/observer/ObserverSpecies.py
+++ b/py/observer/ObserverSpecies.py
@@ -171,6 +171,7 @@ class ObserverSpecies(QObject):
     totalCatchCountChanged = pyqtSignal(QVariant, arguments=['count'], name='totalCatchCountChanged')
     totalCatchCountFGChanged = pyqtSignal(QVariant, arguments=['count'], name='totalCatchCountFGChanged')
     reactivateSpecies = pyqtSignal(QVariant, arguments=['speciesCompItemId'])  #FIELD-2039
+    selectedSpeciesItemChanged = pyqtSignal()
 
     species_list_types = (
         'Full',  # Full list from SPECIES table of observer.db
@@ -1095,6 +1096,7 @@ class ObserverSpecies(QObject):
 
             self._logger.info('Set species item {}'.format(self._current_speciescomp_item.species_comp_item))
             self.counts_weights.currentSpeciesCompItem = item_id
+            self.selectedSpeciesItemChanged.emit()  # FIELD-2095: custom signal for species switch
         except SpeciesCompositionItems.DoesNotExist:
             self.clear_current_species_item_id()
         except ValueError:

--- a/py/observer/ObserverTrip.py
+++ b/py/observer/ObserverTrip.py
@@ -161,10 +161,17 @@ class ObserverTrip(QObject):
         """
         try:
             is_fixed_gear = ObserverTrip.get_fg_value()
-            newtrip = Trips.create(user=observer_id, vessel=vessel_id, program=program_id,
-                                   partial_trip='F', trip_status='FALSE', created_by=observer_id,
-                                   created_date=ObserverDBUtil.get_arrow_datestr(),
-                                   is_fg_trip_local=is_fixed_gear)
+            newtrip = Trips.create(
+                user=observer_id,
+                vessel=vessel_id,
+                program=program_id,
+                partial_trip='F',
+                trip_status='FALSE',
+                created_by=observer_id,
+                created_date=ObserverDBUtil.get_arrow_datestr(),
+                is_fg_trip_local=is_fixed_gear,
+                data_source=ObserverDBUtil.get_data_source()  # FIELD-2099: setting data source initially
+            )
 
             self.add_trip(newtrip)
             return newtrip

--- a/py/observer/Sets.py
+++ b/py/observer/Sets.py
@@ -222,8 +222,10 @@ class Sets(QObject):
             if avg_hook_count and c.gear_segments_sampled:
                 old_hooks = c.hooks_sampled
                 new_hooks = round(avg_hook_count * c.gear_segments_sampled)
-                self._logger.info(f'Catch {c.catch} Hooks sampled {old_hooks} -> {new_hooks}')
+                new_hooks_unrounded = avg_hook_count * c.gear_segments_sampled
+                self._logger.info(f'Catch {c.catch} Hooks sampled {old_hooks} -> {new_hooks} (unrounded = {new_hooks_unrounded})')
                 c.hooks_sampled = new_hooks
+                c.hooks_sampled_unrounded = new_hooks_unrounded  # FIELD-2102: this is the val used for OTC recalc
                 c.save()
 
 

--- a/qml/observer/BiospecimensScreen.qml
+++ b/qml/observer/BiospecimensScreen.qml
@@ -515,7 +515,12 @@ ColumnLayout {
                         verticalAlignment: Text.AlignVCenter
                     }
                 }
-
+                TableViewColumn { // FIELD-2087: debriefer QA/QC purposes
+                    role: "created_date"
+                    title: "Created"
+                    width: 200
+                    visible: appstate.trips.debrieferMode   // Make visible for debriefers
+                }
                 FramConfirmDialog {
                     id: confirmDeleteEntry
                     visible: false

--- a/qml/observer/CatchCategoriesDetailsScreen.qml
+++ b/qml/observer/CatchCategoriesDetailsScreen.qml
@@ -797,7 +797,7 @@ Item {
 
                             model: discardModel
                             ObserverGroupButton {
-                                visible: discard_id != -1
+                                visible: ['-1', '12', '15'].indexOf(discard_id) == -1  // FIELD-2104
                                 text: discard_id
                                 exclusiveGroup: groupDR
                                 Layout.preferredWidth: layoutCCDetails.buttonsize

--- a/qml/observer/CatchCategoriesFGScreen.qml
+++ b/qml/observer/CatchCategoriesFGScreen.qml
@@ -795,6 +795,12 @@ Item {
                 width: 50
                 visible: false   // Make visible for debugging - to check sort order.
             }
+            TableViewColumn {  // FIELD-2087: debriefer QA/QC purposes
+                role: "created_date"
+                title: "Created"
+                width: 200
+                visible: appstate.trips.debrieferMode   // Make visible for debriefers
+            }
 //            TableViewColumn {
 //                role: "notes"
 //                title: "Notes"

--- a/qml/observer/CatchCategoriesScreen.qml
+++ b/qml/observer/CatchCategoriesScreen.qml
@@ -809,6 +809,12 @@ Item {
                 width: 50
                 visible: false   // Make visible for debugging - to check sort order.
             }
+            TableViewColumn {  // FIELD-2087: debriefer QA/QC purposes
+                role: "created_date"
+                title: "Created"
+                width: 200
+                visible: appstate.trips.debrieferMode   // Make visible for debriefers
+            }
 //            TableViewColumn {
 //                role: "notes"
 //                title: "Notes"

--- a/qml/observer/CountsWeightsScreen.qml
+++ b/qml/observer/CountsWeightsScreen.qml
@@ -333,7 +333,7 @@ Item {
                         model: modeSC.discardModel
 
                         ObserverGroupButton {
-                            visible: discard_id != -1
+                            visible: ['-1', '12', '15'].indexOf(discard_id) == -1  // FIELD-2104
                             text: discard_id
                             exclusiveGroup: groupDR
                             Layout.preferredWidth: 50

--- a/qml/observer/CountsWeightsScreen.qml
+++ b/qml/observer/CountsWeightsScreen.qml
@@ -38,6 +38,13 @@ Item {
             }
         }
     }
+    Connections {
+        // FIELD-2095: clears out sticky tab states after species switch
+        target: appstate.catches.species
+        onSelectedSpeciesItemChanged: {
+            NBSM.unsaveTabEnableState()
+        }
+    }
 
     function basketWeightIsTooHigh(weight) {
         // Maximum trawling basket weight is specified in the SETTINGS table of Observer.db

--- a/qml/observer/ObserverSM.qml
+++ b/qml/observer/ObserverSM.qml
@@ -440,6 +440,9 @@ DSM.StateMachine {
         id: sets_state
         onEntered: {
             console.info(">>>>----> Entered SETS state");
+            if (['set', 'tally_state', 'bs_entry_state', 'species_fg_entry_state', 'cc_entry_fg_state'].indexOf(currentStateName) > -1) {
+                appstate.sets.updateCurrentSetCalcs()
+            }
             currentStateName = "sets_state";
             if (!appstate.isFixedGear) {
                 console.error("Gear type is not set to FG.");

--- a/qml/observer/SetsScreen.qml
+++ b/qml/observer/SetsScreen.qml
@@ -164,6 +164,21 @@ Item {
                 appstate.sets.updateModelOTC(otc_fg, fishing_activity_num);
             }
         }
+
+        Connections {
+            target: appstate.sets
+            onDoPredMissedWeights: {
+                dlgDoPredMissed.message = "Species listed do not have retained samples\nto auto-calc dropoff/predated basket weights.\nManual weight entry required:\n\n" + common_names
+                dlgDoPredMissed.open()
+            }
+        }
+        FramNoteDialog {
+            id: dlgDoPredMissed
+            width: 450
+            height: 400
+            bkgcolor: '#FA8072'
+            title: "Null Basket Weights!"
+        }
     }
 
     TrawlOkayDialog {

--- a/qml/observer/SpeciesFGScreen.qml
+++ b/qml/observer/SpeciesFGScreen.qml
@@ -734,6 +734,16 @@ Item {
                 font.pixelSize: 20
                 Layout.preferredWidth: 50
             }
+            ObserverSunlightButton {
+                // FIELD-1900: allow kick-off of set-wide calculations, then refresh species weights
+                id: btnUpdateSetCalcs
+                Layout.leftMargin: 50
+                text: "Run Set Calcs"
+                onClicked: {
+                    appstate.sets.updateCurrentSetCalcs()
+                    tvSelectedSpecies.activate_recalc_all()  // use to refresh weight shown in UI
+                }
+            }
         }
     } // ListView
 

--- a/qml/observer/SpeciesFGScreen.qml
+++ b/qml/observer/SpeciesFGScreen.qml
@@ -612,6 +612,12 @@ Item {
                    horizontalAlignment: Text.AlignHCenter
                }
             }
+            TableViewColumn {  // FIELD-2087: debriefer QA/QC purposes
+                role: "created_date"
+                title: "Created"
+                width: 200
+                visible: appstate.trips.debrieferMode   // Make visible for debriefers
+            }
 
             function activate_recalc_all() {
                 // intended only for use with WM15 (perf reasons)

--- a/qml/observer/SpeciesScreen.qml
+++ b/qml/observer/SpeciesScreen.qml
@@ -628,6 +628,12 @@ Item {
                 title: "Ct"
                 width: 70
             }
+            TableViewColumn {  // FIELD-2087: debriefer QA/QC purposes
+                role: "created_date"
+                title: "Created"
+                width: 200
+                visible: appstate.trips.debrieferMode   // Make visible for debriefers
+            }
             function activate_recalc_all() {
                 // intended only for use with WM15 (perf reasons)
                 console.warn("Recalculating weights for all " + rowCount + " rows.");

--- a/qml/observer/TripDetailsFGScreen.qml
+++ b/qml/observer/TripDetailsFGScreen.qml
@@ -315,7 +315,16 @@ Item {
                     }
                 }
                 onTextChanged: {
+                    if (text === '"Not Listed"') { // FIELD-2076: handle missing captain
+                        dlgSkipperNL.open();
+                        text = '';
+                    }
                     appstate.trips.currentSkipperName = text;
+                }
+                FramNoteDialog {  // FIELD-2076: tell user to report via comments
+                    id: dlgSkipperNL
+                    width: 500
+                    message: "Please leave the skipper field blank and the\nname of the missing skipper in a comment.\n\nContact Jim Fellows for DB adjustment\n at james.fellows@noaa.gov."
                 }
             }
 

--- a/qml/observer/TripDetailsScreen.qml
+++ b/qml/observer/TripDetailsScreen.qml
@@ -324,7 +324,16 @@ Item {
                     }
                 }
                 onTextChanged: {
+                    if (text === '"Not Listed"') { // FIELD-2076: handle missing captain
+                        dlgSkipperNL.open();
+                        text = '';
+                    }
                     appstate.trips.currentSkipperName = text;
+                }
+                FramNoteDialog {  // FIELD-2076: tell user to report via comments
+                    id: dlgSkipperNL
+                    width: 500
+                    message: "Please leave the skipper field blank and the\nname of the missing skipper in a comment.\n\nContact Jim Fellows for DB adjustment\n at james.fellows@noaa.gov."
                 }
             }
 

--- a/qml/observer/codebehind/CountsWeightsNewBasketSM.js
+++ b/qml/observer/codebehind/CountsWeightsNewBasketSM.js
@@ -201,6 +201,16 @@ function saveTabEnableState() {
     }
 }
 
+function unsaveTabEnableState() {
+    // FIELD-2095: clears out sticky tab states after species switch
+    if (originalTabEnablesSaved) {
+        originalTabCCEnable = true;
+        originalTabSpEnable = true;
+        originalTabBSEnable = true;
+        originalTabEnablesSaved = false;
+    }
+}
+
 function enableTabNavigation(doEnable) {
     if (!doEnable) {
         // Consider adding CC to this: tabView.enableEntryTabs(false);


### PR DESCRIPTION
User can now simply tally dropoff/predated fish and rely on the retained weights from the same species (or complex in certain situations) to auto-calculate the weight.  Calculation is kicked off after exiting a set, or via a button on the Species screen.  Warnings will pop if retained weights are not available for a given species.

https://www.fisheries.noaa.gov/jira/browse/FIELD-1900