### PR TITLE
New feature to perform auto-calc of Dropoff/Predated fish weights

### DIFF
--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -331,39 +331,6 @@ class ObserverCatches(QObject):
             self._logger.warning(fmt_str.format(catchcat_common_name))
             return None
 
-    @staticmethod
-    def get_species_complex(cc_id):
-        """
-        Return list of species ids related to catch category
-        Match species on 1.) catch category ID in many-to-many SpeciesCatchCategories table
-        2.) catch category name == species common name in Species table
-        3.) catch category code == species pacfin code in Species table
-        Static method so classes above (Sets) can use this in calculations
-        :param cc_id: Catch Category DB ID
-        :return: list (empty list if nothing found)
-        """
-        try:
-            cc = CatchCategories.get(CatchCategories.catch_category == cc_id)
-        except CatchCategories.DoesNotExist as e:
-            return []
-
-        # get linked species via SpeciesCatchCategories
-        spcc = SpeciesCatchCategories.select(
-            SpeciesCatchCategories.species
-        ).where(
-            SpeciesCatchCategories.catch_category == cc_id
-        )
-
-        # get species matched on pacfin code / catch category code
-        spp = Species.select(
-            Species.species
-        ).where(
-            (fn.Lower(Species.common_name) == cc.catch_category_name.lower()) |
-            (Species.pacfin_code == cc.catch_category_code)
-        )
-
-        return [s.species.species for s in spcc | spp]
-
     @pyqtProperty(QVariant, notify=catchIdChanged)
     def currentCatchCatCode(self):
         if self._current_catch:

--- a/py/observer/ObserverCatches.py
+++ b/py/observer/ObserverCatches.py
@@ -331,6 +331,39 @@ class ObserverCatches(QObject):
             self._logger.warning(fmt_str.format(catchcat_common_name))
             return None
 
+    @staticmethod
+    def get_species_complex(cc_id):
+        """
+        Return list of species ids related to catch category
+        Match species on 1.) catch category ID in many-to-many SpeciesCatchCategories table
+        2.) catch category name == species common name in Species table
+        3.) catch category code == species pacfin code in Species table
+        Static method so classes above (Sets) can use this in calculations
+        :param cc_id: Catch Category DB ID
+        :return: list (empty list if nothing found)
+        """
+        try:
+            cc = CatchCategories.get(CatchCategories.catch_category == cc_id)
+        except CatchCategories.DoesNotExist as e:
+            return []
+
+        # get linked species via SpeciesCatchCategories
+        spcc = SpeciesCatchCategories.select(
+            SpeciesCatchCategories.species
+        ).where(
+            SpeciesCatchCategories.catch_category == cc_id
+        )
+
+        # get species matched on pacfin code / catch category code
+        spp = Species.select(
+            Species.species
+        ).where(
+            (fn.Lower(Species.common_name) == cc.catch_category_name.lower()) |
+            (Species.pacfin_code == cc.catch_category_code)
+        )
+
+        return [s.species.species for s in spcc | spp]
+
     @pyqtProperty(QVariant, notify=catchIdChanged)
     def currentCatchCatCode(self):
         if self._current_catch:

--- a/py/observer/ObserverSpecies.py
+++ b/py/observer/ObserverSpecies.py
@@ -240,7 +240,7 @@ class ObserverSpecies(QObject):
 
         self._species_comp_items_model = ObserverSpeciesCompModel()
 
-        self._counts_weights = CountsWeights()
+        self._counts_weights = CountsWeights(self)
         self._filter_name = ''  # Filter both by common_name and by scientific_name
 
         self.current_protocol_str = ''  # store protocol lookup, e.g. 'FL, WS'
@@ -1506,6 +1506,36 @@ class ObserverSpecies(QObject):
     @pyqtProperty(QVariant, notify=totalCatchCountChanged)
     def totalCatchCount(self):
         return self._total_haul_count
+
+    @staticmethod
+    def get_related_species(species_id):
+        """
+        If species is one of a few where multiple need to be compared,
+        return a list of related species, else return that species only
+        :param species_id: species DB id (int)
+        :return: int[]
+        """
+        complexes = {
+            'thornyhead': [
+                10239,  # longspine
+                10492,  # shortspine / longspine
+                10491  # shortspine
+            ],
+            'shortraker': [
+                10254,  # shortraker
+                10427,  # shortraker/rougheye/blackspotted
+                10490  # rougheye/blackspotted
+            ],
+            'skate': [
+                10334,  # big skate
+                10337,  # longnose skate
+                10338  # sandpaper skate
+            ]
+        }
+        for species in complexes.values():
+            if species_id in species:
+                return species
+        return [species_id]
 
 
 class TestObserverSpecies(unittest.TestCase):

--- a/qml/observer/ObserverSM.qml
+++ b/qml/observer/ObserverSM.qml
@@ -440,6 +440,9 @@ DSM.StateMachine {
         id: sets_state
         onEntered: {
             console.info(">>>>----> Entered SETS state");
+            if (['set', 'tally_state', 'bs_entry_state', 'species_fg_entry_state', 'cc_entry_fg_state'].indexOf(currentStateName) > -1) {
+                appstate.sets.updateCurrentSetCalcs()
+            }
             currentStateName = "sets_state";
             if (!appstate.isFixedGear) {
                 console.error("Gear type is not set to FG.");

--- a/qml/observer/SetsScreen.qml
+++ b/qml/observer/SetsScreen.qml
@@ -164,6 +164,21 @@ Item {
                 appstate.sets.updateModelOTC(otc_fg, fishing_activity_num);
             }
         }
+
+        Connections {
+            target: appstate.sets
+            onDoPredMissedWeights: {
+                dlgDoPredMissed.message = "Species listed do not have retained samples\nto auto-calc dropoff/predated basket weights.\nManual weight entry required:\n\n" + common_names
+                dlgDoPredMissed.open()
+            }
+        }
+        FramNoteDialog {
+            id: dlgDoPredMissed
+            width: 450
+            height: 400
+            bkgcolor: '#FA8072'
+            title: "Null Basket Weights!"
+        }
     }
 
     TrawlOkayDialog {

--- a/qml/observer/SpeciesFGScreen.qml
+++ b/qml/observer/SpeciesFGScreen.qml
@@ -734,6 +734,16 @@ Item {
                 font.pixelSize: 20
                 Layout.preferredWidth: 50
             }
+            ObserverSunlightButton {
+                // FIELD-1900: allow kick-off of set-wide calculations, then refresh species weights
+                id: btnUpdateSetCalcs
+                Layout.leftMargin: 50
+                text: "Run Set Calcs"
+                onClicked: {
+                    appstate.sets.updateCurrentSetCalcs()
+                    tvSelectedSpecies.activate_recalc_all()  // use to refresh weight shown in UI
+                }
+            }
         }
     } // ListView
 


### PR DESCRIPTION
User can now simply tally dropoff/predated fish and rely on the retained weights from the same species (or complex in certain situations) to auto-calculate the weight. Calculation is kicked off after exiting a set, or via a button on the Species screen. Warnings will pop if retained weights are not available for a given species.

https://www.fisheries.noaa.gov/jira/browse/FIELD-1900