### PR TITLE
#214: trawl backdeck version num added to home screen title and build…

### DIFF
--- a/py/trawl/StateMachine.py
+++ b/py/trawl/StateMachine.py
@@ -15,6 +15,7 @@ from PyQt5.QtCore import pyqtProperty, pyqtSlot, QVariant, pyqtSignal, QObject
 from PyQt5.QtQml import QJSValue
 from dateutil import parser
 from py.trawl.TrawlBackdeckDB_model import TypesLu, PrincipalInvestigatorLu
+from py.trawl.TrawlBackdeckConfig import TRAWL_BACKDECK_VERSION
 from peewee import *
 import logging
 
@@ -40,7 +41,7 @@ class StateMachine(QObject):
         super().__init__()
         self._app = app
         self._db = db
-
+        self._version = TRAWL_BACKDECK_VERSION
         self._haul = self._initialize_selected_haul()
         self._species = {}
         self._initialize_selected_species()
@@ -55,6 +56,10 @@ class StateMachine(QObject):
                 .where(PrincipalInvestigatorLu.full_name == "FRAM Standard Survey").get().principal_investigator
         except DoesNotExist as ex:
             self._principal_investigator = None
+
+    @pyqtProperty(QVariant)
+    def version(self):
+        return self._version
 
     @pyqtProperty(QVariant, notify=principalInvestigatorSelected)
     def principalInvestigator(self):

--- a/py/trawl/TrawlBackdeckConfig.py
+++ b/py/trawl/TrawlBackdeckConfig.py
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+# Name:        TrawlBackdeckConfig.py
+# Purpose:     Hold global variables to be shared across all modules of the Trawl Backdeck program.
+#
+# Author:      Jim Fellows <james.fellows@noaa.gov>
+#
+# Created:     March 2021
+# License:     MIT
+# ------------------------------------------------------------------------------
+
+"""
+TRAWL_BACKDECK VERSION STRING
+
+The convention for the TRAWL_BACKDECK version string follows the standard proposed by
+Semantic Versioning 2.0.0 (http://semver.org/#semantic-versioning-200) -
+the standard three major, minor, and patch fields, plus a field for an incrementing
+build number.  MAJOR will be replaced with YEAR, as a new build occurs every year
+and users need to know what year they've been using.  Past year builds may be compatible, but
+this is not guaranteed.
+
+From semver:cdi
+
+"Given a version number MAJOR.MINOR.PATCH, increment the:
+
+* MAJOR version when you make incompatible API changes (Annual increment),
+* MINOR version when you add functionality in a backwards-compatible manner, and
+* PATCH version when you make backwards-compatible bug fixes.
+
+"Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format."
+
+Paragraph 10 of the semver standard allows a build metadata field to be appended to these three fields,
+separated with a plus sign (not a period).
+
+The backdeck version string convention is:
+
+    <YEAR>.<Minor>.<Patch>+<BuildNumber>
+
+BuildNum may increase independently of the first three fields. The simplest convention for build number
+is to have the build system auto-increment the build number with each build.
+
+The justification for including a build number: it is useful when supporting apps in the field to know
+that each build has a unique version string which could be used to bring up the source tree
+as it stood for that particular build.
+"""
+
+TRAWL_BACKDECK_VERSION = "2021.1.0+2"

--- a/qml/trawl/HomeScreen.qml
+++ b/qml/trawl/HomeScreen.qml
@@ -22,7 +22,6 @@ Item {
 //        else
 //            btnProcessCatch.state = qsTr("disabled")
 
-        main.title = qsTr("Field Collector - Trawl Survey - Backdeck - Home");
 //        updateHaulDetails()
     }
 

--- a/qml/trawl/TrawlBackdeckStateMachine.qml
+++ b/qml/trawl/TrawlBackdeckStateMachine.qml
@@ -49,6 +49,9 @@ DSM.StateMachine {
             stateMachine.screen = "home"
             // TODO (Todd Hay) Call the haulSelected signal
 //            settings.haul
+
+            // #213: Update home screen with app version whenever home state is entered
+            main.title = qsTr("Field Collector - Trawl Survey - Backdeck " + stateMachine.version + " - Home");
         }
 
         DSM.SignalTransition {


### PR DESCRIPTION
Logic borrowed from optecs.  Version is semantic versioning 2.0 but with year as first number to follow how this app is usually developed (changes are typically once per year for survey prep).  Version num is inserted anytime Home screen is entered, and is rolled into build number for zip file name as well.  Var in TrawlBackdeckConfig.py is incremented everytime build happens.