### PR TITLE
FIELD-1910: Cast DR 15 comparison as string

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+12"
+optecs_version = "2.1.3+15"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/qml/observer/CatchCategoriesDetailsFGScreen.qml
+++ b/qml/observer/CatchCategoriesDetailsFGScreen.qml
@@ -75,7 +75,7 @@ Item {
                 return "";
             }
 
-            if (discard_reason === '12' || discard_reason === 15)
+            if (discard_reason === '12' || discard_reason === '15') // FIELD-1910: DR vals should be strings
             {
                 console.log('DR is dropoff/pred, not warning about Biospecimens.');
                 return "";

--- a/qml/observer/CountsWeightsFGScreen.qml
+++ b/qml/observer/CountsWeightsFGScreen.qml
@@ -1011,7 +1011,7 @@ Item {
                 property string req_type: "requested/required"
                 function prompt_if_bio_needed() {
                     var discard_reason = gridDR.current_discard_id;
-                    if (discard_reason === '12' || discard_reason === 15)
+                    if (discard_reason === '12' || discard_reason === '15') // FIELD-1910: DR vals should be strings
                     {
                         console.log('DR is dropoff/pred, not warning about Biospecimens.')
                         return;


### PR DESCRIPTION
Bug causing biospecimen warning prompt when DR15 is selected should be resolved by doing string comparison on discard reason value.  Build 2.1.3+15.