### PR TITLE
FIELD-1900: round calc vals, sticky avg, add skate unid, prevent tally first

### DIFF
--- a/py/observer/CountsWeights.py
+++ b/py/observer/CountsWeights.py
@@ -87,9 +87,10 @@ class CountsWeights(QObject):
 
     def _clear_counts_and_weights(self):
         self._avg_weight = None
-        self.subsampleWeight = None  # use pyqtProperty to trigger setter
-        self.subsampleCount = None  # use pyqtProperty to trigger setter
-        self._subsample_avg_weight = None
+        if not self._is_fixed_gear:  # subsample funcs only on trawl
+            self.subsampleWeight = None  # use pyqtProperty to trigger setter
+            self.subsampleCount = None  # use pyqtProperty to trigger setter
+            self._subsample_avg_weight = None
         self._species_weight = None
         self._species_fish_count = None
         self._total_tally = None
@@ -516,8 +517,6 @@ class CountsWeights(QObject):
             self._species_weight = self._extrapolated_species_weight = self._actual_weight = self._avg_weight = None
             self.emit_calculated_weights()
             return
-        # elif self._weighted_baskets == 0 and self._observer_species.discardReason in ['12', '15']:
-
 
         self._species_weight = self._extrapolated_species_weight = self._actual_weight = species_weight
 
@@ -706,6 +705,7 @@ class CountsWeights(QObject):
 
     @pyqtProperty(QVariant, notify=tallyFGFishCountChanged)
     def tallyTimesAvgWeight(self):
+        # FIELD-1900: avoid nulling out weight for DR 12 and 15 with null avg (avg from retained will be used)
         if self._observer_species.discardReason in ['12', '15'] and self._weighted_baskets == 0:
             self._logger.info(f"DR12/15 without baskets, not calculating species weight with avg val = {self.avgWeight}")
             return self._current_species_comp_item.species_weight

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+11"
+optecs_version = "2.1.3+16"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBUtil.py
+++ b/py/observer/ObserverDBUtil.py
@@ -19,6 +19,7 @@ import socket
 import shutil
 import re
 
+from decimal import *
 from typing import Any, Dict, List, Type, Union
 
 from apsw import BusyError
@@ -610,6 +611,20 @@ class ObserverDBUtil:
         except SpeciesCompositionItems.DoesNotExist:
             logging.error(f'Could not delete species comp item ID {comp_item_id}')
 
+    @staticmethod
+    def round_up(val, precision='.01'):
+        """
+        https://stackoverflow.com/questions/56820/round-doesnt-seem-to-be-rounding-properly#56833
+        function to properly round up
+
+        TODO: replace the Decimal rounding functionality throughout the app, using this in Sets.
+        TODO: replace in CountsWeights.tallyTimesAvgWeight, CountsWeights._calculate_totals...
+        :return: rounded float (defaults to two points of precision)
+        """
+        try:
+            return float(Decimal(val).quantize(Decimal(precision), rounding=ROUND_HALF_UP))
+        except TypeError:
+            return None
 
 class TestObserverDBUtil(unittest.TestCase):
     """

--- a/py/observer/ObserverSpecies.py
+++ b/py/observer/ObserverSpecies.py
@@ -580,6 +580,15 @@ class ObserverSpecies(QObject):
             self._logger.debug(f'FG Tally avg Weight {avg_weight}')
             idx = self._get_cur_species_comp_item_idx()
 
+            # FIELD-1900: reverse engineer avg for DO/PRED fish where no weights are taken
+            if self.discardReason in ['12', '15'] and not avg_weight:
+                try:
+                    avg_weight = ObserverDBUtil.round_up(
+                        self._current_speciescomp_item.species_weight / self._current_speciescomp_item.species_number
+                    )
+                except TypeError as e:  # if weight  or number is None, catch error, continue with None avg
+                    pass
+
             self._species_comp_items_model.setProperty(
                 idx, 'avg_weight', avg_weight)
             self._logger.debug(f'Avg Weight updated to {avg_weight}')
@@ -1575,7 +1584,8 @@ class ObserverSpecies(QObject):
             'skate': [
                 10334,  # big skate
                 10337,  # longnose skate
-                10338  # sandpaper skate
+                10338,  # sandpaper skate
+                10340   # skate unid, including here per FIELD-1900
             ]
         }
         for species in complexes.values():

--- a/qml/observer/CountsWeightsFGScreen.qml
+++ b/qml/observer/CountsWeightsFGScreen.qml
@@ -1139,10 +1139,15 @@ Item {
                         fontsize: 30
                         property bool enableAudio: ObserverSettings.enableAudio
                         onClicked: {
-                            appstate.catches.species.counts_weights.addToTallyFGCount(1)
-                            if (enableAudio) {
-                                soundPlayer.play_sound("keyInput", false)
+                            if (!gridDR.is_dr_set() && !appstate.catches.species.isRetained) {
+                                dlgSelectDRWarning.open();  // FIELD-1900: prevent tally if DR not set
+                            } else {
+                                appstate.catches.species.counts_weights.addToTallyFGCount(1)
+                                if (enableAudio) {
+                                    soundPlayer.play_sound("keyInput", false)
+                                }
                             }
+
                         }
 
                     }
@@ -1383,7 +1388,7 @@ Item {
     ////
     FramNoteDialog {
         id: dlgSelectDRWarning
-        message: "Select a discard reason\nprior to adding baskets."
+        message: "Select a discard reason\nprior to adding baskets or counts."
         font_size: 18
     }
 

--- a/qml/observer/SpeciesFGScreen.qml
+++ b/qml/observer/SpeciesFGScreen.qml
@@ -619,9 +619,11 @@ Item {
                 visible: appstate.trips.debrieferMode   // Make visible for debriefers
             }
 
-            function activate_recalc_all() {
+            function activate_recalc_all(reselect) {
+                if (reselect === undefined) reselect = false  // default value; default is to clear selected species
                 // intended only for use with WM15 (perf reasons)
                 console.warn("Recalculating weights for all " + rowCount + " rows.");
+                var startingRow = tvSelectedSpecies.currentRow
                 for (var i = 0; i < rowCount; i++) {
                     clear_selection();
                     currentRow = i;
@@ -629,6 +631,12 @@ Item {
                     activate_selected_species();
                     // delay needed?
                     clear_selection();
+                }
+                // FIELD-1900: if reselect, reselect/activate original row
+                if (reselect) {
+                    tvSelectedSpecies.currentRow = startingRow;
+                    tvSelectedSpecies.selection.select(startingRow)
+                    activate_selected_species()
                 }
             }
             function activate_selected_species() {
@@ -741,12 +749,12 @@ Item {
                 text: "Run Set Calcs"
                 onClicked: {
                     appstate.sets.updateCurrentSetCalcs()
-                    tvSelectedSpecies.activate_recalc_all()  // use to refresh weight shown in UI
+                    tvSelectedSpecies.activate_recalc_all(true)  // use to refresh weight shown in UI
+                    enable_remove_button(true);
                 }
             }
         }
     } // ListView
-
 
     FramSlidingKeyboard {
         id: slidingKeyboardSpecies
@@ -778,7 +786,6 @@ Item {
             visible = false;
         }
     }
-
     FramNoteDialog {
         id: dlgSpeciesAlreadyInSelected
         property string common_name


### PR DESCRIPTION
Several things included on this commit:
- New func in ObserverDBUtil to do decimal rounding
- Avg retained val in calc is correctly rounded
- User can't start tallying without selecting DR reason
- Skate Unid added to skate complex
- Avg val for DR12/15 derived from existing Count/Weight on species screen
- Beefing up comments

tagged with 2.1.3+16