### PR TITLE
FIELD-2087: add time to basket created date string first, then recast

### DIFF
--- a/py/observer/CountsWeights.py
+++ b/py/observer/CountsWeights.py
@@ -180,13 +180,13 @@ class CountsWeights(QObject):
             return
 
         try:
-
             new_basket = SpeciesCompositionBaskets.create(
                     species_comp_item=self._current_species_comp_item,
                     basket_weight_itq=weight,
                     fish_number_itq=count,
                     created_by=ObserverDBUtil.get_current_user_id(),
-                    created_date=ObserverDBUtil.get_arrow_datestr(date_format=ObserverDBUtil.oracle_date_format),
+                    # FIELD-2087: Using default dateformat for time display; reformat before sync later
+                    created_date=ObserverDBUtil.get_arrow_datestr(date_format=ObserverDBUtil.default_dateformat),
                     is_fg_tally_local=1 if self._is_fixed_gear else None,
                     is_subsample=None
             )
@@ -225,7 +225,8 @@ class CountsWeights(QObject):
                     catch=current_catch_id,
                     basket_weight=weight,
                     created_by=ObserverDBUtil.get_current_user_id(),
-                    created_date=ObserverDBUtil.get_arrow_datestr(date_format=ObserverDBUtil.oracle_date_format),
+                    # FIELD-2087: Using default dateformat for time display; reformat before sync later
+                    created_date=ObserverDBUtil.get_arrow_datestr(date_format=ObserverDBUtil.default_dateformat),
             )
             self._baskets_model.add_basket(new_basket)
             self._logger.info(f'Added addl basket wt: {weight}')

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+18"
+optecs_version = "2.1.3+19"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBSyncController.py
+++ b/py/observer/ObserverDBSyncController.py
@@ -839,8 +839,15 @@ class ObserverDBSyncController(QObject):
                 # "SPECIES_COMP_BASKET_ID", "SPECIES_COMP_ITEM_ID",
                 row.basket_weight_itq, row.fish_number_itq,
                 # "BASKET_WEIGHT_ITQ", "FISH_NUMBER_ITQ",
-                row.created_date, row.created_by, None,
-                # "CREATED_DATE", "CREATED_BY", "MODIFIED_BY",
+                # FIELD-2087: recast to Oracle date; TODO: fix sync_upload.SPECIES_COMP_BASKETS created_date dtype
+                ObserverDBUtil.convert_datestr(
+                    row.created_date,
+                    ObserverDBUtil.default_dateformat,
+                    ObserverDBUtil.oracle_date_format
+                ),
+                # "CREATED_DATE"
+                row.created_by, None,
+                # "CREATED_BY", "MODIFIED_BY",
                 ObserverDBUtil.get_data_source(), None, None
                 # "DATA_SOURCE", "ROW_PROCESSED", "ROW_STATUS"
             ]
@@ -895,8 +902,15 @@ class ObserverDBSyncController(QObject):
                 row.catch_addtl_baskets, row.catch.catch,
                 # "BASKET_WEIGHT",
                 row.basket_weight,
-                # "CREATED_DATE", "CREATED_BY",
-                row.created_date, row.created_by,
+                # "CREATED_DATE",
+                # FIELD-2087: recast to Oracle date; TODO: fix sync_upload.CAB created_date dtype
+                ObserverDBUtil.convert_datestr(
+                    row.created_date,
+                    ObserverDBUtil.default_dateformat,
+                    ObserverDBUtil.oracle_date_format
+                ),
+                #"CREATED_BY",
+                row.created_by,
                 # "MODIFIED_DATE", "MODIFIED_BY",
                 None, None,
                 # "DATA_SOURCE", "ROW_PROCESSED", "ROW_STATUS",

--- a/py/observer/ObserverDBUtil.py
+++ b/py/observer/ObserverDBUtil.py
@@ -282,6 +282,17 @@ class ObserverDBUtil:
             return arrow_time.format(ObserverDBUtil.javascript_dateformat)
 
     @staticmethod
+    def convert_datestr(datestr, existing_fmt, desired_fmt):
+        """
+        pass in datestr, parse into datetime, then reformat back to string
+        :param datestr: str
+        :param existing_fmt: str (e.g. default_dateformat)
+        :param desired_fmt: str (e.g. oracle_date_format)
+        :return: str (new format)
+        """
+        return arrow.get(datestr, existing_fmt).format(desired_fmt)
+
+    @staticmethod
     def log_peewee_model_dependencies(logger, dependencies, context_message=None):
         """
         Log the non-null fields of records in the list of dependencies.

--- a/qml/observer/CountsWeightsFGScreen.qml
+++ b/qml/observer/CountsWeightsFGScreen.qml
@@ -903,7 +903,7 @@ Item {
             id: tvBaskets
             x: grpMeasurementType.x + grpMeasurementType.width + 20
             y: 190
-            width: 400
+            width: appstate.trips.debrieferMode ? 600 : 400  // add width of created_date col if debreifer mode
             height: main.height - 335
             enabled: !isEditingExistingBasket && !NBSM.isEnteringNewBasket()
 
@@ -963,7 +963,12 @@ Item {
 //                }
 //            }
 
-
+            TableViewColumn {  // FIELD-2087: debriefer QA/QC purposes
+                role: "created_date"
+                title: "Created"
+                width: 200
+                visible: appstate.trips.debrieferMode   // Make visible for debriefers
+            }
             onClicked: {
                 if (!btnEditBasket.checked) {
                     tvBaskets.selection.clear();


### PR DESCRIPTION
Creating baskets with default date string format so time is displayed.  Then reformatting for oracle prior to sync.  Better fix is to make sync_upload schema consistent in SPECIES_COMPOSITION_BASKETS and CATCH_ADDITIONAL_BASKETS tables.