### PR TITLE
FIELD-1471: Restricting subsample avg calcs to the current day

### DIFF
--- a/py/observer/CountsWeights.py
+++ b/py/observer/CountsWeights.py
@@ -337,8 +337,7 @@ class CountsWeights(QObject):
         ).where(
             (Trips.trip == ObserverDBUtil.get_current_trip_id()) &
             (Species.species.in_(species_list)) &
-            # (fn.substr(FishingActivities.created_date, 1, 10) == fn.substr(ObserverDBUtil.get_arrow_datestr(), 1, 10)) &
-            (fn.substr(FishingActivities.created_date, 1, 10) == fn.substr(SpeciesCompositionItems.created_date, 1, 10)) &
+            (fn.substr(SpeciesCompositionItems.created_date, 1, 10) == fn.substr(ObserverDBUtil.get_arrow_datestr(), 1, 10)) &
             (SpeciesCompositionBaskets.is_subsample == 1)
         ).scalar()
 
@@ -367,8 +366,7 @@ class CountsWeights(QObject):
         ).where(
             (Trips.trip == ObserverDBUtil.get_current_trip_id()) &
             (Species.species.in_(species_list)) &
-            # (fn.substr(FishingActivities.created_date, 1, 10) == fn.substr(ObserverDBUtil.get_arrow_datestr(), 1, 10)) &
-            (fn.substr(FishingActivities.created_date, 1, 10) == fn.substr(SpeciesCompositionItems.created_date, 1, 10)) &
+            (fn.substr(SpeciesCompositionItems.created_date, 1, 10) == fn.substr(ObserverDBUtil.get_arrow_datestr(), 1, 10)) &
             (SpeciesCompositionBaskets.is_subsample == 1)
         ).scalar()
 
@@ -589,9 +587,9 @@ class CountsWeights(QObject):
             if self._subsample_avg_mode == 1:
                 note = f'SPECIES_NUMBER=WEIGHT/SUBSAMPLE_AVG={species_weight}/{round(self._subsample_avg_weight, 2)}'
                 self._observer_species.species_comp_item_notes = note
-            elif species_extrapolated_count:
+            elif self._extrapolated_species_fish_count:
                 note = f'SPECIES_NUMBER=(NO_COUNT_WEIGHT/FISH_AVG)+ACTUAL_COUNT=(' \
-                       f'{species_weight - species_counted_weight}/{self._avg_weight})+{species_fish_count}'
+                       f'{species_weight - species_counted_weight}/{ObserverDBUtil.round_up(self._avg_weight)})+{species_fish_count}'
                 self._observer_species.species_comp_item_notes = note
 
             if self._current_weight_method == '8' and self._total_tally is not None:

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+20"
+optecs_version = "2.1.3+21"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2


### PR DESCRIPTION
Existing bug only restricted to hauls and baskets created on the same day, not the current days baskets.  New query gets all baskets created that day.

*Also cleaning up notes field in species comp by rounding avg val.