### PR TITLE
FIELD-2114: Adding optecs version to data_source

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+22"
+optecs_version = "2.1.3+23"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBUtil.py
+++ b/py/observer/ObserverDBUtil.py
@@ -30,6 +30,7 @@ from py.observer.ObserverDBModels import Settings, Programs, TripChecks, Species
 from playhouse.apsw_ext import APSWDatabase
 from playhouse.shortcuts import dict_to_model
 from playhouse.test_utils import test_database
+from py.observer.ObserverConfig import optecs_version
 
 import unittest
 
@@ -611,7 +612,7 @@ class ObserverDBUtil:
 
     @staticmethod
     def get_data_source() -> str:
-        return'optecs ' + socket.gethostname()
+        return f'optecs_{optecs_version} {socket.gethostname()}'  # FIELD-2114: adding version to data_source
 
     @staticmethod
     def del_species_comp_item(comp_item_id, delete_baskets=True):


### PR DESCRIPTION
So we now know what Optecs version was being used after trip data is submitted.

Tested sync without any issues.

See https://www.fisheries.noaa.gov/jira/browse/FIELD-2114