### PR TITLE
Implement hookmatrix versioning

### DIFF
--- a/build/build_config.py
+++ b/build/build_config.py
@@ -1,0 +1,46 @@
+
+# -----------------------------------------------------------------------------
+# Name:        build_config.py
+# Purpose:     Central location for build related vars across different field software apps
+#
+# Author:      Jim Fellows <james.fellows@noaa.gov>
+#
+# Created:     July 2021
+# ------------------------------------------------------------------------------
+
+import os
+import fileinput
+import re
+import sys
+
+
+def increment_build_number(build_config_path, var_name, do_increment=True) -> str:
+    """
+    Increment build number.  Assumes format of versioning is MAJOR.MINOR.PATCH+BUILD,
+    where each component is an undefined number of digits.  Copied from build_observer,
+    but altered to accommodate other app version variables.
+
+    :param build_config_path: relative path to config file where version# lives
+    :param var_name: name of python version variable (assumes format VAR_NAME = '')
+    :param do_increment: perform increment. For testing, can set this to False
+    :return: version string
+    """
+    if not os.path.exists(build_config_path):
+        print(f'*** Unable to increment build #.  Cant find config file {build_config_path}.')
+        return ''
+    version_info = None
+    for i, line in enumerate(fileinput.input(build_config_path, inplace=1)):
+        m = re.search(var_name + r' = \"[0-9]*\.[0-9]*\.[0-9]*\+(?P<build_num>[0-9]*)', line)
+        if m:
+            old_build_num = int(m.group('build_num'))
+            if do_increment:
+                line = line.replace('+' + str(old_build_num), '+' + str(old_build_num + 1))
+            m = re.search(var_name + r' = \"(?P<ver>[0-9]*\.[0-9]*\.[0-9]*\+[0-9]*)', line)
+            version_info = m.group('ver')
+        sys.stdout.write(line)
+
+    return version_info
+
+
+if __name__ == '__main__':
+    print(increment_build_number('../py/hookandline_hookmatrix/HookMatrixConfig.py', 'HOOKMATRIX_VERSION'))

--- a/build/build_hookandline_hookmatrix.py
+++ b/build/build_hookandline_hookmatrix.py
@@ -15,6 +15,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from build_config import increment_build_number
+
 # Useful library. http://click.pocoo.org/5/api/#click.confirm
 import click
 
@@ -34,6 +36,9 @@ QRC_PATH = str(Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), '.
 QRCPY_PATH = str(Path(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../py/hookandline_hookmatrix/hookandline_hookmatrix_qrc.py')).resolve())
 print('\npyrcc: ' + PYRCC_DIR + '\nqrc: ' + QRC_PATH + '\nqrcpy: ' + QRCPY_PATH + '\n')
 subprocess.check_output([PYRCC_DIR, QRC_PATH, '-o', QRCPY_PATH])
+
+# increment build number
+version = increment_build_number('../py/hookandline_hookmatrix/HookMatrixConfig.py', 'HOOKMATRIX_VERSION')
 
 includefiles = [
 		path_sqlite_dll,  # for some reason this went away in cx_freeze 5.0		
@@ -96,4 +101,4 @@ setup(
 )
 
 # Zip up our creation
-buildzipper.create_zip_archive(base_folder=deployed_path, filedesc='hookandline_hookmatrix')
+buildzipper.create_zip_archive(base_folder=deployed_path, filedesc=f'hookandline_hookmatrix_{version}')

--- a/py/hookandline_hookmatrix/HookMatrixConfig.py
+++ b/py/hookandline_hookmatrix/HookMatrixConfig.py
@@ -1,0 +1,41 @@
+# -----------------------------------------------------------------------------
+# Name:        HookMatrixConfig.py
+# Purpose:     Hold global variables to be shared across all modules of the Hookmatrix program.
+#
+# Author:      Jim Fellows <james.fellows@noaa.gov>
+#
+# Created:     July 2021
+# ------------------------------------------------------------------------------
+"""
+The convention for the HookMatrix version string follows the standard proposed by
+Semantic Versioning 2.0.0 (http://semver.org/#semantic-versioning-200) -
+the standard three major, minor, and patch fields, plus a field for an incrementing
+build number.  Because this software is released annually, the major version represents the calendar
+year (see https://calver.org/#scheme) for a more intuitive version number.
+
+From semver:cdi
+
+"Given a version number MAJOR.MINOR.PATCH, increment the:
+
+* MAJOR version when you make incompatible API changes,
+* MINOR version when you add functionality in a backwards-compatible manner, and
+* PATCH version when you make backwards-compatible bug fixes.
+
+"Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format."
+
+Paragraph 10 of the semver standard allows a build metadata field to be appended to these three fields,
+separated with a plus sign (not a period).
+
+The HookMatrix version string convention is:
+
+    <Major>.<Minor>.<Patch>+<BuildNumber>
+
+BuildNum may increase independently of the first three fields. The simplest convention for build number
+is to have the build system auto-increment the build number with each build.
+
+The justification for including a build number: it is useful when supporting apps in the field to know
+that each build has a unique version string which could be used to bring up the source tree
+as it stood for that particular build.
+"""
+
+HOOKMATRIX_VERSION = "2021.0.0+2"

--- a/py/hookandline_hookmatrix/StateMachine.py
+++ b/py/hookandline_hookmatrix/StateMachine.py
@@ -16,8 +16,9 @@ from PyQt5.QtQml import QJSValue
 import logging
 import arrow
 
+from py.hookandline_hookmatrix.HookMatrixConfig import HOOKMATRIX_VERSION
+
 APP_NAME = 'HookMatrix'
-SW_VERSION = '1.0.4'
 
 class StateMachine(QObject):
     """
@@ -61,7 +62,7 @@ class StateMachine(QObject):
         self._db = db
 
         self._app_name = APP_NAME
-        self._software_version = SW_VERSION
+        self._software_version = HOOKMATRIX_VERSION
 
         logging.info(f"{self._app_name} v{self._software_version}")
         logging.info(f"Starting date/time: {arrow.now()}")


### PR DESCRIPTION
Initial commit for hookmatrix versioning.  Follows semvar convention, but uses calendar year in place of generic major version number.

Fix #236 