### PR TITLE
#82: highlight fish caught as green and bold

### DIFF
--- a/py/hookandline_hookmatrix/HookMatrixConfig.py
+++ b/py/hookandline_hookmatrix/HookMatrixConfig.py
@@ -38,4 +38,4 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.
 """
 
-HOOKMATRIX_VERSION = "2021.0.0+2"
+HOOKMATRIX_VERSION = "2021.0.0+3"

--- a/py/hookandline_hookmatrix/Hooks.py
+++ b/py/hookandline_hookmatrix/Hooks.py
@@ -62,6 +62,29 @@ class Hooks(QObject):
         self._rpc = self._app.rpc
 
         self._full_species_list_model = FullSpeciesListModel(self._app)
+        self._non_fish_items = self._get_non_fish_items()  # added for issue #82
+
+    def _get_non_fish_items(self):
+        """
+        Get list of hook items that are not fish/taxonomic
+        e.g. Bait Back, No Bait, No Hook, Multiple Hook, Undeployed (subject to change going forward)
+        :return: str[]
+        """
+        sql = '''
+            select  display_name
+            from    catch_content_lu
+            where   taxonomy_id is null
+        '''
+        return [i[0] for i in self._rpc.execute_query(sql=sql)]
+
+    @pyqtSlot(QVariant, name='isFish', result=bool)
+    def is_fish(self, hooked_item):
+        """
+        Used for hook text styling (see #82)
+        :param hooked_item: string from UI
+        :return: bool
+        """
+        return hooked_item not in self._non_fish_items
 
     @pyqtProperty(FramListModel, notify=fullSpeciesListModelChanged)
     def fullSpeciesListModel(self):

--- a/qml/hookandline_hookmatrix/HookItem.qml
+++ b/qml/hookandline_hookmatrix/HookItem.qml
@@ -18,9 +18,11 @@ Item {
         Label {
             text: "Hook " + hookNumber
             font.pixelSize: 24
+            font.underline: true
             horizontalAlignment: Text.AlignHCenter
-            Layout.preferredWidth: 260
+            Layout.preferredWidth: 200
             Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignRight
         }
         RowLayout {
             spacing: 10
@@ -40,6 +42,7 @@ Item {
                 id: tfHook
 //                placeholderText: "Hook " + hookNumber
                 font.pixelSize: 24
+                font.bold: hooks.isFish(tfHook.text)  // #82: bold fish items
                 Layout.preferredWidth: 200
                 Layout.preferredHeight: 60
                 property string color: "white"
@@ -56,7 +59,7 @@ Item {
                     }
                 }
                 style: TextFieldStyle {
-//                    textColor: "black"
+                    textColor: hooks.isFish(tfHook.text) ? "green" : "black"  // #82: highlight fish green
                     background: Rectangle {
 //                        radius: 2
 //                        implicitWidth: 100


### PR DESCRIPTION
Highlight fish hooked as green and bold.  Non-fish items (e.g. Bait Back) are pulled from db and will stay as black regular text.  Centering/underlining text labels

Close #82