### PR TITLE
#239: Revamp GP button relations.  Auto-select Undeployed/Excluded

### DIFF
--- a/py/hookandline_hookmatrix/GearPerformance.py
+++ b/py/hookandline_hookmatrix/GearPerformance.py
@@ -32,37 +32,22 @@ class GearPerformance(QObject):
     @pyqtSlot(str, name="addGearPerformance")
     def add_gear_performance(self, gear_performance: str):
         """
-        Method to add a gear performance problem
-        :param problem:
-        :return:
+        #239: Revamp of gp button relationships.  Removing delete all when "No Problems" selected
+        Upsert gear performance record for existing operation id
+        :param gear_performance: str
+        :return: None (inserts to db)
         """
         op_id = self.get_angler_op_id()
-
-        # Delete the existing No Problems gear performance
         try:
-            if gear_performance == "No Problems":
-                sql = """
-                    DELETE FROM OPERATION_ATTRIBUTES WHERE OPERATION_ID = ? AND ATTRIBUTE_TYPE_LU_ID IN
-                        (SELECT LOOKUP_ID FROM LOOKUPS WHERE TYPE = 'Angler Gear Performance');
-                """
-            else:
-                sql = """
-                    DELETE FROM OPERATION_ATTRIBUTES WHERE OPERATION_ID = ? AND ATTRIBUTE_TYPE_LU_ID IN
-                        (SELECT LOOKUP_ID FROM LOOKUPS WHERE TYPE = 'Angler Gear Performance' AND
-                                                             VALUE = 'No Problems');
-                """
-            params = [op_id, ]
-            self._rpc.execute_query(sql=sql, params=params)
-
-        except Exception as ex:
-
-            logging.error(f"Error deleting the gear performances: {ex}")
-
-        try:
-            self._app.drops.upsert_operation_attribute(operation_id=op_id, lu_type="Angler Gear Performance",
-                                                     lu_value=gear_performance, value_type="alpha",
-                                                       value=None, indicator=None)
-
+            self._app.drops.upsert_operation_attribute(
+                operation_id=op_id,
+                lu_type="Angler Gear Performance",
+                lu_value=gear_performance,
+                value_type="alpha",
+                value=None,
+                indicator=None
+            )
+            logging.debug(f"Upserting gear performance {gear_performance} with operation_id {op_id}")
         except Exception as ex:
             logging.error(f"Error adding the no problems gear performances: {ex}")
 
@@ -75,7 +60,6 @@ class GearPerformance(QObject):
         :return:
         """
         op_id = self.get_angler_op_id()
-
         try:
             sql = """
                 DELETE FROM OPERATION_ATTRIBUTES WHERE OPERATION_ID = ? AND ATTRIBUTE_TYPE_LU_ID IN
@@ -86,7 +70,6 @@ class GearPerformance(QObject):
             self._rpc.execute_query(sql=sql, params=params)
 
         except Exception as ex:
-
             logging.error(f"Error deleting the gear performance: {ex}")
 
     @pyqtSlot(name="selectGearPerformance", result=QVariant)

--- a/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
+++ b/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
@@ -56,6 +56,7 @@ Item {
         anchors.right: clPerformances.left
         anchors.rightMargin: 100
         anchors.verticalCenter: parent.verticalCenter
+        // #239: Bind onCheckedChange to addGearPerformance/deleteGearPerformance to just interact with btn.checked
         BackdeckButton {
             id: btnNoProblems
             text: qsTr("No Problems")
@@ -64,18 +65,19 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnLostHooks.checked = false;
-                btnLostGangion.checked = false;
-                btnLostSinker.checked = false;
-                btnMinorTangle.checked = false;
-                btnMajorTangle.checked = false;
-                btnUndeployed.checked = false;
-                btnExclude.checked = false;
-
-                if (checked)
-                    gearPerformance.addGearPerformance("No Problems");
-                else
-                    gearPerformance.deleteGearPerformance("No Problems");
+                if (checked) {
+                    btnLostHooks.checked = false;
+                    btnLostGangion.checked = false;
+                    btnLostSinker.checked = false;
+                    btnMinorTangle.checked = false;
+                    btnMajorTangle.checked = false;
+                    btnUndeployed.checked = false;
+                    btnExclude.checked = false;
+                }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
             }
         } // btnNoProblems
 //        	-- No Problems (default value - use this if no performance issues identified)
@@ -95,13 +97,14 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-
-                if (checked)
-                    gearPerformance.addGearPerformance("Lost Hooks");
-                else
-                    gearPerformance.deleteGearPerformance("Lost Hooks");
-
+                if (checked) {
+                    btnNoProblems.checked = false;
+                    btnUndeployed.checked = false;
+                }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
             }
         } // btnLostHooks
         BackdeckButton {
@@ -112,15 +115,15 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-
                 if (checked) {
-                    gearPerformance.addGearPerformance("Lost Gangion");
-                    // #145: auto-select lost sinker whenever lost gangion is selected
-                    btnLostSinker.checked = true
-                    gearPerfomance.addGearPerformance("Lost Sinker");
-                } else
-                    gearPerformance.deleteGearPerformance("Lost Gangion");
+                    btnNoProblems.checked = false;
+                    btnUndeployed.checked = false;
+                    btnLostSinker.checked = true // #145: auto-select lost sinker whenever lost gangion is selected
+                }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
             }
         } // btnLostGangion
         BackdeckButton {
@@ -131,16 +134,18 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-
-                if (checked)
-                    gearPerformance.addGearPerformance("Lost Sinker");
+                if (checked) {
+                    btnNoProblems.checked = false;
+                    btnUndeployed.checked = false;
+                }
                 else {
                     // #145: auto-unselect lost gangion whenever lost sinker is unselected
                     btnLostGangion.checked = false
-                    gearPerformance.deleteGearPerformance("Lost Sinker");
-                    gearPerformance.deleteGearPerformance("Lost Gangion");
                 }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
             }
         } // btnLostSinker
         BackdeckButton {
@@ -151,11 +156,14 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-                if (checked)
-                    gearPerformance.addGearPerformance("Minor Tangle");
-                else
-                    gearPerformance.deleteGearPerformance("Minor Tangle");
+                if (checked) {
+                    btnNoProblems.checked = false;
+                    btnUndeployed.checked = false;
+                }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance("Minor Tangle")
+                else gearPerformance.deleteGearPerformance("Minor Tangle")
             }
         } // btnMinorTangle
         BackdeckButton {
@@ -166,11 +174,14 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-                if (checked)
-                    gearPerformance.addGearPerformance("Major Tangle");
-                else
-                    gearPerformance.deleteGearPerformance("Major Tangle");
+                if (checked) {
+                    btnNoProblems.checked = false;
+                    btnUndeployed.checked = false;
+                }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance("Major Tangle")
+                else gearPerformance.deleteGearPerformance("Major Tangle")
             }
         } // btnMajorTangle
         BackdeckButton {
@@ -181,11 +192,20 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-                if (checked)
-                    gearPerformance.addGearPerformance("Undeployed");
-                else
-                    gearPerformance.deleteGearPerformance("Undeployed");
+                if (checked) {
+                    // deselect all gp buttons
+                    btnNoProblems.checked = false;
+                    btnLostHooks.checked = false;
+                    btnLostGangion.checked = false;
+                    btnLostSinker.checked = false;
+                    btnMinorTangle.checked = false;
+                    btnMajorTangle.checked = false;
+                    btnExclude.checked = true;  // #239: Auto-select exclude when undeployed selected
+                    }
+            }
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
             }
         } // btnUndeployed
 
@@ -196,6 +216,7 @@ Item {
         anchors.left: clPerformances.right
         anchors.leftMargin: 100
         anchors.verticalCenter: parent.verticalCenter
+
         BackdeckButton {
             id: btnExclude
             text: qsTr("Exclude")
@@ -204,14 +225,15 @@ Item {
             checkable: true
             checked: false
             onClicked: {
-                btnNoProblems.checked = false;
-                if (checked)
-                    gearPerformance.addGearPerformance("Exclude");
-                else
-                    gearPerformance.deleteGearPerformance("Exclude");
-
+                if (!checked) {
+                    btnUndeployed.checked = false
+                }
             }
-        } // btnNoProblems
+            onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
+                if (checked) gearPerformance.addGearPerformance(text)
+                else gearPerformance.deleteGearPerformance(text)
+            }
+        }
 //        	-- No Problems (default value - use this if no performance issues identified)
 //	-- Lost Hook(s) -- Lost Gangion  -- Lost Sinker  -- Minor Tangle  -- Major Tangle  -- Undeployed
 


### PR DESCRIPTION
Fix #239 Excluded is always selected with Undeployed.  Undeployed is always unselected if Excluded is unselected.

All Gear Performance buttons now use onCheckedChange signal to addGearPerformance/deleteGearPerformance.  Allows code to mark button as checked/unchecked, and implicitly delete DB records.  Removed delete statements from addGearPerformance as they're unnecessary now.