### PR TITLE
#241: Revised signaling so gear perf labels can persist

### DIFF
--- a/py/hookandline_hookmatrix/StateMachine.py
+++ b/py/hookandline_hookmatrix/StateMachine.py
@@ -88,34 +88,6 @@ class StateMachine(QObject):
 
         self._drop_time_state = "enter"
 
-
-    @pyqtSlot(name="createGearPerformanceLabel")
-    def create_gear_performance_label(self):
-        """
-        Method to create the new gear performance label for the stateMachine
-        drop and angler
-        :return:
-        """
-        gear_perf_results = self._app.gear_performance.selectGearPerformance()
-        logging.info('gear performance: {gearPerfResults}')
-        gfMap = {
-            "No Problems": "NP", "Lost Hooks": "LH", "Lost Gangion": "LG", "Minor Tangle": "MI",
-            "Major Tangle": "MA", "Undeployed": "UN", "Exclude": "EX", "Lost Sinker": "LS"
-        }
-        label = ""
-
-        for x in gear_perf_results:
-            label += gfMap[x] + ","
-
-        if len(label) > 6:
-            label = label[0:5] + '...'
-        elif len(label) > 0 and label[-1] == ",":
-            label = label[:-1]
-
-        logging.info(f"gear performance label: {label}")
-        self.gearPerformanceLabelCreated.emit(self._drop, self._angler, label)
-
-
     @pyqtProperty(str, notify=swVersionChanged)
     def swVersion(self):
         """

--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -10,6 +10,7 @@ Item {
 
     property string anglerPosition: "Bow";
     property string anglerLetter: "A";
+    property variant anglerOpId: drops.getAnglerOpId(itmDropTab.dropOpId, anglerLetter) // letter changes on each angler
     property string anglerName: "Bob Jones";
     property double startSeconds;
     property bool isRunning: false;
@@ -92,22 +93,6 @@ Item {
                 break;
             case "swap":
                 break;
-        }
-    }
-
-    Connections {
-        target: stateMachine //hmSM
-        onGearPerformanceLabelCreated: updateGearPerformanceLabel(drop, angler, label)
-    }
-    function updateGearPerformanceLabel(drop, angler, label) {
-        if (drop === itmDropTab.dropNumber && angler === anglerLetter) {
-            console.info('drop = ' + drop + ', angler = ' + angler + ' vs. drop = ' +
-                itmDropTab.dropNumber + ', anglerLetter: ' + anglerLetter);
-            if (label !== null && label !== "") {
-                txtGearPerformance.text = "Gear\n" + label;
-            } else {
-                txtGearPerformance.text = "Gear\nPerf."
-            }
         }
     }
 
@@ -437,9 +422,17 @@ Item {
                 color: "transparent"
                 Text {
                     id: txtGearPerformance
-                    text: qsTr("Gear\nPerf.")
+                    text: drops.getAnglerGearPerfsLabel(anglerOpId)  // #241: query perfs by angler ID
                     font.pixelSize: 24
                     anchors.verticalCenter: parent.verticalCenter
+                    Connections { // #241: receive signal from GearPerformance whenever record is added/deleted
+                        target: gearPerformance
+                        onGearPerformanceChanged: {
+                            if(angler_op_id == anglerOpId) {  // only query if DB Ids match
+                                txtGearPerformance.text = drops.getAnglerGearPerfsLabel(anglerOpId)
+                            }
+                        }
+                    }
                 }
                 Image {
                     id: imgGearPerformance

--- a/qml/hookandline_hookmatrix/DropTab.qml
+++ b/qml/hookandline_hookmatrix/DropTab.qml
@@ -10,6 +10,7 @@ Item {
 
     // TODO Todd Hay - if reopening a site, need to ensure that rtA, rtB, and rtC are enabled
     property string dropNumber: "1"
+    property variant dropOpId: drops.getDropIdFromNumber(dropNumber)  // dropNumber var above changes with each tab
     property int buttonWidth: 140
     property string sinkerWeight: "Sinker\nlb";
 

--- a/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
+++ b/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
@@ -55,15 +55,6 @@ DSM.StateMachine {
                 screens.push(Qt.resolvedUrl("DropsScreen.qml"));
                 drops.selectOperationAttributes(stateMachine.setId)
             } else if ((stateMachine.previousScreen === "hooks") || (stateMachine.previousScreen === "gear_performance")) {
-
-                // Update the gear performance label for the given Angler
-                if (stateMachine.previousScreen === "gear_performance") {
-                    stateMachine.createGearPerformanceLabel();
-                }
-
-                if (stateMachine.previousScreen === "hooks") {
-
-                }
                 screens.pop();
             }
             stateMachine.angler = null;


### PR DESCRIPTION
Steps:
1. Create functions in Drops.py to return Drop and Angler IDs and make them available in DropTabl.qml and DropAngler.qml, respectively
2. Create function in Drops.py that uses Angler Op Id to return gear perf label from DB
3. Set gear perf label text with new function in step 2
4. Whenever gear perf is added or removed, signal to UI that label should be updated (only update label for relevant angler id)

Code for previous label updating has been removed.