### PR TITLE
#79: Format Hooks label on Drops screen

### DIFF
--- a/py/hookandline_hookmatrix/Drops.py
+++ b/py/hookandline_hookmatrix/Drops.py
@@ -437,8 +437,8 @@ class Drops(QObject):
                 ''',
                 params=[self._app.state_machine.siteOpId, drop_num]
             )[0][0]
-        except (IndexError, Exception) as ex:
-            logging.error(f"Unable to get drop op id with drop num {drop_num}; {ex}")
+        except (IndexError, Exception) as ex:  # above query will return nothing if data has yet to be entered
+            logging.debug(f"Unable to get drop op id with drop num {drop_num}; {ex}")
             return None
 
     @pyqtSlot(QVariant, str, name="getAnglerOpId", result=QVariant)
@@ -459,8 +459,8 @@ class Drops(QObject):
                             ''',
                 params=[drop_op_id, angler_letter]
             )[0][0]
-        except (IndexError, Exception) as ex:
-            logging.error(f"Unable to get angler id with drop op id {drop_op_id} angler {angler_letter}; {ex}")
+        except (IndexError, Exception) as ex:  # above query will return nothing if data has yet to be entered
+            logging.debug(f"Unable to get angler id with drop op id {drop_op_id} angler {angler_letter}; {ex}")
             return None
 
     @pyqtSlot(int, name="getAnglerGearPerfsLabel", result=QVariant)
@@ -495,3 +495,103 @@ class Drops(QObject):
         except IndexError as ex:
             logging.error(f"Unable to parse gear perfs {perfs}; {ex}")
             return default
+
+    @pyqtSlot(int, name="getAnglerHooksLabel", result=QVariant)
+    def get_angler_hooks_label(self, angler_op_id):
+        """
+        Select hooks per op_id aka angler from DB.
+        Left join to CTE ensures result will always have 5 rows,
+        unpopulated hooks shown as null
+        :param angler_op_id: int, operations DB id
+        :return: dict[], one per db row. E.g. [{hookNum: "1", hookContent: "Boccacio", isFish: True}...]
+        """
+        try:
+            hooks = self._rpc.execute_query(
+                sql="""
+                    with hooks as (--cartesian join CTE creates 5 records per angler
+                        select
+                                    o.operation_id as angler_op_id
+                                    ,h.hook_num
+                        FROM		operations o
+                        JOIN		(
+                                        select '1' as hook_num
+                                        union all
+                                        select '2'
+                                        union all
+                                        select '3'
+                                        union all
+                                        select '4'
+                                        union all
+                                        select '5'
+                                    ) h
+                                    on 1 = 1
+                        WHERE		o.operation_id = ?
+                        )
+                    select
+                                h.hook_num
+                                ,cc.display_name
+                                ,case
+                                    when cc.content_type_lu_id = 129 then 'Fish Hooked'
+                                    when cc.content_type_lu_id = 130 then 'Other'
+                                    else null
+                                end as content_type
+                    from        hooks h
+                    left join	catch c  --left join ensures 5 rows always returned per angler
+                                on h.angler_op_id = c.operation_id
+                                and h.hook_num = c.receptacle_seq
+                    left join   catch_content_lu cc
+                                on c.hm_catch_content_id = cc.catch_content_id
+                    left JOIN	lookups l
+                                on c.receptacle_type_id = l.lookup_id
+                                and l.value = 'Hook'
+                    order by    h.hook_num desc
+                    """,
+                params=[angler_op_id, ]
+            )
+        except Exception as ex:
+            logging.error(f"Unable to query hooks with angler op id {angler_op_id}; {ex}")
+            return []
+
+        if len(hooks) > 0:
+            hooks_list = [
+                {
+                    'hookNum': h[0],
+                    'hookContent': h[1],
+                    'isFish': self._app.hooks.is_fish(h[1])  # tie in function from hooks
+                }
+                for h in hooks
+            ]
+            return self.format_hooks_label(hooks_list)
+        else:
+            return []
+
+    @staticmethod
+    def format_hooks_label(hooks_list):
+        """
+        format hooks text for RichText QML text object
+        :param hooks_list: list of dicts (e.g. [{'hookNum': 1, 'hookContent': 'Yelloweye', 'isFish': True}]
+        :return: string, rich text
+        """
+        hooks_lbl = 'Hooks<br>'
+
+        if not hooks_list:
+            return hooks_lbl + "\n_,_,_,_,_"
+        elif all(h['hookContent'] == 'Undeployed' for h in hooks_list):  # if all undeployed, set label to UN
+            return hooks_lbl + 'UN'
+        else:
+            for hook in hooks_list:
+                hook_num = hook['hookNum']
+                content = hook['hookContent']
+                is_fish = hook['isFish']
+
+                # label uses rich text to color diff chars differently
+                if not content:
+                    hooks_lbl += f"<font color=\"#000000\">_,</font>"  # black underscore
+                elif is_fish:
+                    hooks_lbl += f"<font color=\"#008000\">{hook_num},</font>"  # green
+                elif not is_fish:
+                    hooks_lbl += f"<font color=\"#000000\">{hook_num},</font>"  # black
+                else:
+                    logging.error(f"Unexpected value {content} for hook {hook_num}")
+
+        return ''.join(hooks_lbl.rsplit(",", 1))  # splits on last comma and joins with empty str (remove last comma)

--- a/py/hookandline_hookmatrix/Hooks.py
+++ b/py/hookandline_hookmatrix/Hooks.py
@@ -54,6 +54,7 @@ class Hooks(QObject):
 
     fullSpeciesListModelChanged = pyqtSignal()
     hooksSelected = pyqtSignal(QVariant, arguments=["results", ])
+    hooksChanged = pyqtSignal(QVariant, arguments=["angler_op_id"])  # signal to update hooks label in DropAngler.qml
 
     def __init__(self, app=None, db=None):
         super().__init__()
@@ -204,6 +205,8 @@ class Hooks(QObject):
             adh = f"{self._app.state_machine.angler}{self._app.state_machine.drop}{self._app.state_machine.hook}"
             notify = {"speciesUpdate": {"station": "HookMatrix", "set_id": self._app.state_machine.setId, "adh": adh}}
             self._rpc.execute_query(sql=sql, params=params, notify=notify)
+            logging.info(f"Hooks changed for angler op id {angler_op_id}")
+            self.hooksChanged.emit(angler_op_id)  # received by DropAngler.qml
 
         except Exception as ex:
 
@@ -298,6 +301,8 @@ class Hooks(QObject):
                 notify = {"speciesUpdate": {"station": "HookMatrix", "set_id": self._app.state_machine.setId, "adh": adh}}
                 self._rpc.execute_query(sql=sql, params=params, notify=notify)
                 logging.info(f"hook deletion completed, params = {params}")
+                self.hooksChanged.emit(angler_op_id)  # received by DropAngler.qml
+                logging.info(f"Hooks changed for angler op id {angler_op_id}")
 
         except Exception as ex:
 

--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -422,7 +422,7 @@ Item {
                 color: "transparent"
                 Text {
                     id: txtGearPerformance
-                    text: drops.getAnglerGearPerfsLabel(anglerOpId)  // #241: query perfs by angler ID
+                    text: anglerOpId ? drops.getAnglerGearPerfsLabel(anglerOpId) : "Gear\nPerf."  // #241: query perfs by angler ID
                     font.pixelSize: 24
                     anchors.verticalCenter: parent.verticalCenter
                     Connections { // #241: receive signal from GearPerformance whenever record is added/deleted
@@ -459,9 +459,17 @@ Item {
                 enabled: false
                 Text {
                     id: txtHooks
-                    text: qsTr("Hooks")
+                    text: anglerOpId ? drops.getAnglerHooksLabel(anglerOpId) : "Hooks<br>\n_,_,_,_,_"
                     font.pixelSize: 24
                     anchors.verticalCenter: parent.verticalCenter
+                    Connections {
+                        target: hooks
+                        onHooksChanged: {
+                            if (angler_op_id == anglerOpId) {
+                                txtHooks.text = drops.getAnglerHooksLabel(angler_op_id)
+                            }
+                        }
+                    }
                 }
                 Image {
                     id: imgHooks


### PR DESCRIPTION
Steps here:
1. Function in Drops to query hooks by angler op id
2. Format query result with rich QML text, color fish green
3. Set text of hooks label to this label result, if angler op id is available
4. Signal anytime hook is added or deleted to update hook label

Tweak default value for gear perf as well.