### PR TITLE
#144: Upsert undeployed hooks from GP screen when Undeployed selected

### DIFF
--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -470,6 +470,14 @@ Item {
                             }
                         }
                     }
+                    Connections {
+                        target: gearPerformance
+                        onHooksUndeployed: {
+                            if (angler_op_id == anglerOpId) {
+                                txtHooks.text = drops.getAnglerHooksLabel(angler_op_id)
+                            }
+                        }
+                    }
                 }
                 Image {
                     id: imgHooks

--- a/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
+++ b/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
@@ -201,6 +201,7 @@ Item {
                     btnMinorTangle.checked = false;
                     btnMajorTangle.checked = false;
                     btnExclude.checked = true;  // #239: Auto-select exclude when undeployed selected
+                    dlgUndeployed.open()  // #144: dialog to ask to undeploy all hooks
                     }
             }
             onCheckedChanged: {  // add to DB anytime checked, remove anytime unchecked
@@ -238,7 +239,18 @@ Item {
 //	-- Lost Hook(s) -- Lost Gangion  -- Lost Sinker  -- Minor Tangle  -- Major Tangle  -- Undeployed
 
     } // clPerformances
-
+    OkayCancelDialog {
+        // #144: auto-populate hooks 1-5 as Undeployed when undeployed option clicked
+        id: dlgUndeployed
+        message: '"Undeployed" gear perf. selected.'
+        action: 'Set all Angler ' + stateMachine.angler + ' hooks to "Undeployed"?'
+        btnOkay.text: "Yes"
+        btnCancel.text: "No"
+        onAccepted: {
+            gearPerformance.upsertHooksToUndeployed()
+        }
+        onRejected: {}
+    }
     Footer {
         id: framFooter
         height: 50


### PR DESCRIPTION
Steps:
1. Function that updates/inserts hooks 1-5 for current angler created
2. Dialog pops on GearPerformance.qml asking.  Yes calls upsert function
3. After upsert, signal sent to DropAngler to update Hooks label on drops screen.