### PR TITLE
#143: Allow nav between hooks and gp and back

### DIFF
--- a/py/hookandline_hookmatrix/GearPerformance.py
+++ b/py/hookandline_hookmatrix/GearPerformance.py
@@ -17,6 +17,7 @@ class GearPerformance(QObject):
         self._db = db
         self._rpc = self._app.rpc
 
+    @pyqtSlot(name="getAnglerOpId", result=int)  # 143: expose as pyqtSlot
     def get_angler_op_id(self):
         """
         Method to return the angler operation id from the given state machine angler letter.  The Angler Operation ID

--- a/py/hookandline_hookmatrix/Hooks.py
+++ b/py/hookandline_hookmatrix/Hooks.py
@@ -95,6 +95,7 @@ class Hooks(QObject):
         """
         return self._full_species_list_model
 
+    @pyqtSlot(name="getAnglerOpId", result=int)  # 143: expose as pyqtSlot
     def get_angler_op_id(self):
         """
         Method to return the angler operation id from the given state machine angler letter.  The Angler Operation ID

--- a/qml/hookandline_hookmatrix/DropsScreen.qml
+++ b/qml/hookandline_hookmatrix/DropsScreen.qml
@@ -305,6 +305,7 @@ Item {
     Header {
         id: framHeader
         title: getHeaderTitle();
+        backwardTitle: "Sites"
         height: 50
     }
     TabView {

--- a/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
+++ b/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
@@ -6,6 +6,7 @@ Item {
 
     property int buttonHeight: 80;
     property int buttonWidth: 2 * buttonHeight;
+    property variant isAnglerDoneFishing: drops.isAnglerDoneFishing(gearPerformance.getAnglerOpId())
 
     Connections {
         target: gearPerformance
@@ -44,11 +45,22 @@ Item {
             if (stop_processing) break;
         }
     }
-
     Header {
         id: framHeader
         title: "Gear Performance: Drop " + stateMachine.drop + " - Angler " + stateMachine.angler
         height: 50
+        backwardTitle: "Drops"
+        forwardTitle: drops.getAnglerHooksLabel(gearPerformance.getAnglerOpId())
+        forwardEnabled: isAnglerDoneFishing
+        forwardVisible: isAnglerDoneFishing
+        Connections {
+            target: gearPerformance
+            onHooksUndeployed: {
+                if (gearPerformance.getAnglerOpId() == angler_op_id) {
+                    framHeader.forwardTitle = drops.getAnglerHooksLabel(gearPerformance.getAnglerOpId())
+                }
+            }
+        }
     }
     ColumnLayout {
         id: clNoProblems

--- a/qml/hookandline_hookmatrix/Header.qml
+++ b/qml/hookandline_hookmatrix/Header.qml
@@ -12,17 +12,14 @@ BorderImage {
     height: 45
 
     property alias backButton: backButton
-//    property alias textLeftBanner: textLeftBanner
-//    property alias textRightBanner: textRightBanner
-    property string title: "Title"
-    property string backwardTitle: ""
-    property string forwardTitle: ""
-    property variant forwardAction: null;
-
-
-    // width of toolbar area that can be clicked to nav back/fwd
-    property int nav_click_width: 100
-    property bool forward_enabled: true
+    property alias forwardButton: forwardButton
+    property string forwardTitle: ""  // sets text label for forward nav
+    property string backwardTitle: ""  // sets text label for backward nav
+    property string title: "Title"  // center title text
+    property int nav_click_width: 100 // width of toolbar area that can be clicked to nav back/fwd
+    property bool forwardEnabled: false  // allow disabling of forward nav
+    property bool forwardVisible: false  // allow hiding of forward nav
+    property variant forwardAction: null;  // do we need this???
 
     signal backClicked();
     onBackClicked: {
@@ -49,7 +46,23 @@ BorderImage {
         forward_enabled = enable;
         console.debug("Forward button enable: " + forward_enabled);
     }
-
+    signal forwardClicked()
+    onForwardClicked: {
+        // #143: refactored for nav between gear perf and hooks screens
+        var current_screen = stateMachine.screen
+        if (forwardEnabled) {
+            console.log("Clicked forward from " + stateMachine.screen)
+            switch(current_screen) {
+                case "gear_performance":
+                    smHookMatrix.to_hooks_state()
+                    break;
+                case "hooks":
+                    smHookMatrix.to_gear_performance_state()
+                    break;
+            }
+        }
+    }
+/*  #143: commenting out but leaving for reference, see onForwardClicked above for current functionality
     signal forwardClicked(string to_state, string text_clicked);
     onForwardClicked: {
         if (stackView.busy || !forward_enabled)
@@ -71,7 +84,7 @@ BorderImage {
         }
 
     }
-
+*/
     function show_buttons(show) {
         // Keeping this here in case we want to add buttons again
         quickButtonRow.visible = show;
@@ -131,7 +144,7 @@ BorderImage {
         x: backButton.x + backButton.width + 20
         anchors.verticalCenter: parent.verticalCenter
         color: "black"
-        text: "" //obsSM.bannerLeftText
+        text: backwardTitle
 
     } // textLeftBanner
     Text {
@@ -141,7 +154,7 @@ BorderImage {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
         color: "black"
-        text: title//obsSM.titleText
+        text: title
     } // textTitle
     Text {
         id: textRightBanner
@@ -150,8 +163,8 @@ BorderImage {
         x: forwardButton.x - this.width - 20
         anchors.verticalCenter: parent.verticalCenter
         color: "black"
-        text: forwardTitle //obsSM.bannerRightText
-        visible: false
+        text: forwardTitle
+        visible: forwardVisible
     } // textRightBanner
     Rectangle {
         id: forwardButton
@@ -160,7 +173,7 @@ BorderImage {
         anchors.rightMargin: 20
         anchors.verticalCenter: parent.verticalCenter
         antialiasing: true
-        visible: false
+        visible: forwardVisible
         height: 40
         radius: 4
         color: "transparent"
@@ -177,12 +190,8 @@ BorderImage {
             width: nav_click_width
 
             onClicked: {
-                forwardAction;
-                console.info('forward')
-//                forwardClicked(obsSM.rightButtonStateName, textRightBanner.text);
+                forwardClicked()
             }
         }
     } // forwardButton
-
-
 }

--- a/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
+++ b/qml/hookandline_hookmatrix/HookMatrixStateMachine.qml
@@ -77,6 +77,9 @@ DSM.StateMachine {
     DSM.State {
         id: gear_performance_state
         onEntered: {
+            if (stateMachine.screen == "hooks") {
+                screens.pop()  // #143: pop hooks off stack so Drops stays second in line
+            }
             stateMachine.previousScreen = stateMachine.screen;
             stateMachine.screen = "gear_performance"
 //            stateMachine.angler = null;
@@ -87,19 +90,29 @@ DSM.StateMachine {
             targetState: drops_state
             signal: to_drops_state
         } // to_drops_state
+        DSM.SignalTransition {  // #143: enable transition to hooks from gp
+            targetState: hooks_state
+            signal: to_hooks_state
+        } // to_hooks_state
     } // gear_performance_state
     DSM.State {
         id: hooks_state
         onEntered: {
+            if (stateMachine.screen === "gear_performance") {
+                screens.pop()  // #143: pop gp off stack so Drops stays second in line
+            }
             stateMachine.previousScreen = stateMachine.screen;
             stateMachine.screen = "hooks"
             screens.push(Qt.resolvedUrl("HooksScreen.qml"));
             hooks.selectHooks();
         }
-
         DSM.SignalTransition {
             targetState: drops_state
             signal: to_drops_state
+        } // to_drops_state
+        DSM.SignalTransition {  // #143: enable transition to gp from hooks
+            targetState: gear_performance_state
+            signal: to_gear_performance_state
         } // to_drops_state
     } // hook_state
 }

--- a/qml/hookandline_hookmatrix/HooksScreen.qml
+++ b/qml/hookandline_hookmatrix/HooksScreen.qml
@@ -211,6 +211,10 @@ Item {
         title: "Drop " + stateMachine.drop + " - Angler " + stateMachine.angler + " - " +
                         stateMachine.anglerName + " - Hooks"
         height: 50
+        backwardTitle: "Drops"
+        forwardTitle: drops.getAnglerGearPerfsLabel(hooks.getAnglerOpId())
+        forwardEnabled: true
+        forwardVisible: true
     }
     ColumnLayout {
         id: clHooks


### PR DESCRIPTION
Steps:
1. In HmStateMachine, allow transitions between gp and hooks.  Pop screen off stack if coming from hooks or gp to the other so we can go back to drops directly
2. Revise header to allow forward nav on these screens, and make forward and back text more explicit
3. Use same signalling logic in drops screen to update/format GP and Hooks labels
4. Hide nav to hooks if angler isn't done fishing; function added to drops to check if angler is done.