### PR TITLE
FIELD-1471: Use actual haul DB id to get haul created date, not haul num

### DIFF
--- a/py/observer/Hauls.py
+++ b/py/observer/Hauls.py
@@ -184,14 +184,20 @@ class Hauls(QObject):
 
     @currentHaulId.setter
     def currentHaulId(self, current_id):
+        """
+        Assigned in HaulsScreen.  Also sets current_haulset_id with dbid here
+        :param current_id: haul number (not DB ID)
+        :return: None
+        """
         self._logger.debug('Set currentHaul using ID {}'.format(current_id))
         try:
             self._current_haul = FishingActivities.get(
                 FishingActivities.trip == self._trip_id,
                 FishingActivities.fishing_activity_num == current_id
             )
-            ObserverDBUtil.db_save_setting('current_haulset_id', current_id)
-            self._logger.info(f"Setting current_haulset_id to {current_id}")
+            # FIELD-1471: setting db id for downstream use in baskets
+            ObserverDBUtil.db_save_setting('current_haulset_id', self._current_haul.fishing_activity)
+            self._logger.debug(f"Setting current_haulset_id to {self._current_haul.fishing_activity}")
             self._internal_haul_idx = self._hauls_model.get_item_index('fishing_activity_num',
                                                                        self._current_haul.fishing_activity_num)
             self._fishing_locations.load_fishing_locations(fishing_activity_id=self._current_haul.fishing_activity)

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+26"
+optecs_version = "2.1.3+28"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBUtil.py
+++ b/py/observer/ObserverDBUtil.py
@@ -26,7 +26,7 @@ from apsw import BusyError
 from peewee import Model, BigIntegerField, BooleanField, DoubleField, FloatField, ForeignKeyField, IntegerField, \
     PrimaryKeyField, SmallIntegerField, TextField, TimestampField
 from py.observer.ObserverDBBaseModel import BaseModel, database
-from py.observer.ObserverDBModels import Settings, Programs, TripChecks, SpeciesCompositionItems
+from py.observer.ObserverDBModels import Settings, Programs, TripChecks, SpeciesCompositionItems, FishingActivities
 from playhouse.apsw_ext import APSWDatabase
 from playhouse.shortcuts import dict_to_model
 from playhouse.test_utils import test_database
@@ -588,6 +588,21 @@ class ObserverDBUtil:
         try:
             return int(ObserverDBUtil.get_setting('current_haulset_id'))
         except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def get_current_haulset_createddate():
+        """
+        Getting created_date for current selected haul/set.
+        :return: date string from database in format MM/DD/YYYY HH:mm
+        """
+        current_faid = ObserverDBUtil.get_current_haulset_id()  # database ID set when haul is selected
+        if current_faid:
+            try:
+                return FishingActivities.get(FishingActivities.fishing_activity == current_faid).created_date
+            except FishingActivities.DoesNotExist:
+                return None
+        else:
             return None
 
     @staticmethod

--- a/py/observer/ObserverState.py
+++ b/py/observer/ObserverState.py
@@ -324,7 +324,11 @@ class ObserverState(QObject):
         if trip_id is None:
             self._logger.info('Current trip ID is not set.')
             return
-
+        # this is also being set in ObserverTrips.tripId.setter, but fails if in debriefer mode (user mismatch).
+        # adding here to ensure trip_number param is definitely set when selecting trip
+        # TODO: consolidate logic for setting trip_number here, or rework ObserverTrip.tripId setter
+        ObserverDBUtil.db_save_setting('trip_number', trip_id)
+        self._logger.debug(f"setting SETTINGS parameter trip_number to {trip_id}")
         trip_id = int(trip_id)  # ensure integer key
         self._trips.tripId = trip_id
         self._hauls.reset()

--- a/py/observer/Sets.py
+++ b/py/observer/Sets.py
@@ -425,14 +425,19 @@ class Sets(QObject):
 
     @currentSetId.setter
     def currentSetId(self, current_id):
+        """
+        Assigned in SetsScreen.  Also sets current_haulset_id with dbid here
+        :param current_id: set number (not DB ID)
+        :return: None
+        """
         self._logger.debug('Set currentSet using ID {}'.format(current_id))
         try:
             self._current_set = FishingActivities.get(
                 FishingActivities.trip == self._trip_id,
                 FishingActivities.fishing_activity_num == current_id
             )
-            ObserverDBUtil.db_save_setting('current_haulset_id', current_id)
-            self._logger.info(f"Setting current_haulset_id to {current_id}")
+            ObserverDBUtil.db_save_setting('current_haulset_id', self._current_set.fishing_activity)
+            self._logger.debug(f"Setting current_haulset_id to {self._current_set.fishing_activity}")
             self._internal_set_idx = self._sets_model.get_item_index('fishing_activity_num',
                                                                      self._current_set.fishing_activity_num)
             self._fishing_locations.load_fishing_locations(fishing_activity_id=self._current_set.fishing_activity)


### PR DESCRIPTION
Bug where query to get current haul created date was using haul num , not haul id.  Issues in debriefer mode where SETTINGS param trip_number was not set due to user mismatch also resolved in ObserverState.

Steps:
1. Also set SETTINGS param trip_number when trip is selected in TripSelectScreen (ObserverState.currentTripId.setter)
2. Set SETTINGS param current_haulset_id to fishing_activity_id in both Hauls and Sets (not haul num)
3. Query subsample calcs using created date of haul using db id and current trip num
4. Move get_current_haulset_createddate() to DBUtil as static method

Also beefing up comments related to FIELD-1471