### PR TITLE
#144: HookMatrix Undeployed Autopopulation

### DIFF
--- a/py/hookandline_hookmatrix/HookMatrixConfig.py
+++ b/py/hookandline_hookmatrix/HookMatrixConfig.py
@@ -38,4 +38,4 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.
 """
 
-HOOKMATRIX_VERSION = "2021.0.0+5"
+HOOKMATRIX_VERSION = "2021.0.0+6"

--- a/py/hookandline_hookmatrix/Hooks.py
+++ b/py/hookandline_hookmatrix/Hooks.py
@@ -65,6 +65,34 @@ class Hooks(QObject):
         self._full_species_list_model = FullSpeciesListModel(self._app)
         self._non_fish_items = self._get_non_fish_items()  # added for issue #82
 
+    @pyqtProperty(bool)
+    def isGearUndeployed(self):
+        """
+        #144: Check if Undeployed has been populated for current angler
+        Used to see if we're changing hook to something other than undeployed when undeployed gear perf is entered
+        TODO: move this to a statemachine property?  Tried but it was annoying, left as is for now - jf
+        :return: boolean
+        """
+        op_id = self.get_angler_op_id()
+        try:
+            undeployed = self._rpc.execute_query(
+                sql='''
+                    select  oa.operation_attribute_id
+                    from    operation_attributes oa
+                    join    lookups l
+                            on oa.attribute_type_lu_id = l.lookup_id
+                    where   oa.operation_id = ?
+                            and l.type = 'Angler Gear Performance'
+                            and l.value = 'Undeployed'
+                ''',
+                params=[op_id, ]
+            )
+        except Exception as e:
+            logging.error(f"Unable to query undeployed gear perfs for angler op id {op_id}")
+            return False
+
+        return len(undeployed) > 0
+
     def _get_non_fish_items(self):
         """
         Get list of hook items that are not fish/taxonomic

--- a/py/hookandline_hookmatrix/Hooks.py
+++ b/py/hookandline_hookmatrix/Hooks.py
@@ -113,7 +113,7 @@ class Hooks(QObject):
         :param hooked_item: string from UI
         :return: bool
         """
-        return hooked_item not in self._non_fish_items
+        return hooked_item not in self._non_fish_items if hooked_item else False
 
     @pyqtProperty(FramListModel, notify=fullSpeciesListModelChanged)
     def fullSpeciesListModel(self):

--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -422,6 +422,8 @@ Item {
                     id: txtGearPerformance
                     text: operationId ? drops.getAnglerGearPerfsLabel(operationId) : "Gear\nPerf."  // #241: query perfs by angler ID
                     font.pixelSize: 24
+                    color: rtGearPerformance.enabled ? 'black' : 'gray'  // #246: gray if disabled
+                    font.italic: !rtGearPerformance.enabled  // #246: italic if disabled
                     anchors.verticalCenter: parent.verticalCenter
                     Connections { // #241: receive signal from GearPerformance whenever record is added/deleted
                         target: gearPerformance
@@ -434,6 +436,7 @@ Item {
                 }
                 Image {
                     id: imgGearPerformance
+                    opacity: rtGearPerformance.enabled ? 1.0 : 0.25  // #246: set image opaque if disabled
                     anchors.left: txtGearPerformance.right
                     anchors.verticalCenter: parent.verticalCenter
                     source: Qt.resolvedUrl("/resources/images/navigation_next_item_dark.png")
@@ -457,14 +460,14 @@ Item {
                 enabled: false
                 Text {
                     id: txtHooks
-                    text: operationId ? drops.getAnglerHooksLabel(operationId) : "Hooks<br>\n_,_,_,_,_"
+                    text: drops.getAnglerHooksLabel(operationId, rtHooks.enabled)
                     font.pixelSize: 24
                     anchors.verticalCenter: parent.verticalCenter
                     Connections {
                         target: hooks
                         onHooksChanged: {
                             if (angler_op_id == operationId) {
-                                txtHooks.text = drops.getAnglerHooksLabel(operationId)
+                                txtHooks.text = drops.getAnglerHooksLabel(operationId, rtHooks.enabled)
                             }
                         }
                     }
@@ -472,7 +475,7 @@ Item {
                         target: gearPerformance
                         onHooksUndeployed: {
                             if (angler_op_id == operationId) {
-                                txtHooks.text = drops.getAnglerHooksLabel(operationId)
+                                txtHooks.text = drops.getAnglerHooksLabel(operationId, rtHooks.enabled)
                             }
                         }
                     }
@@ -480,6 +483,7 @@ Item {
                 Image {
                     id: imgHooks
                     anchors.left: txtHooks.right
+                    opacity: rtHooks.enabled ? 1.0 : 0.25  // #246: set image opaque if disabled
                     anchors.verticalCenter: parent.verticalCenter
                     source: Qt.resolvedUrl("/resources/images/navigation_next_item_dark.png")
                 }

--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -415,6 +415,7 @@ Item {
                 height: 40
                 radius: 4
                 implicitWidth:  txtGearPerformance.implicitWidth + imgGearPerformance.implicitWidth
+                enabled: operationId ? true : false  // # 247: only allow nav to GP after angler id created
                 color: "transparent"
 
                 Text {

--- a/qml/hookandline_hookmatrix/DropAngler.qml
+++ b/qml/hookandline_hookmatrix/DropAngler.qml
@@ -492,6 +492,36 @@ Item {
                     }
                 }
             } // rtHooks
+            Connections {
+            	target: gearPerformance
+            	onAnglerTimeUndeployed: {
+            	    // #144: receive signal from gp when undeployed is selected, set times to undeployed str
+            		if (angler_op_id == operationId) {
+            			switch(time_type) {
+            				case "Start":
+            					btnStart.text = "Start\n" + undeployed_str;
+            					break;
+            				case "Begin Fishing":
+            					btnBeginFishing.text = "Begin Fishing\n" + undeployed_str;
+            					break;
+            				case "First Bite":
+            					btnFirstBite.text = "First Bite\n" + undeployed_str;
+            					break;
+            				case "Retrieval":
+            					btnRetrieval.text = "Retrieval\n" + undeployed_str;
+            					break;
+            				case "At Surface":
+            				    // mimic ending of time recording for normal deployed fishing
+            					btnAtSurface.text = "At Surface\n" + undeployed_str;
+            					lblElapsedTime.text = btnAtSurface.text.replace("At Surface\n", "");
+            					rtHooks.enabled = true;
+            					isRunning = false;
+            					updateButtonStatus("At Surface");
+            					break;
+            			}
+            		}
+            	}
+            }
         } // Buttons
     }
     OkayCancelDialog {

--- a/qml/hookandline_hookmatrix/DropTab.qml
+++ b/qml/hookandline_hookmatrix/DropTab.qml
@@ -60,6 +60,7 @@ Item {
 
             // Insert new OPERATION_ATTRIBUTES records
             operationId = op_ids["Angler A"];
+            anglerA.operationId = operationId  // #251: set op id for angler QML item, this wont change
             drops.upsertOperationAttribute(operationId, luType, luValue, valueType, value, "Angler A");
             console.info('insert Angler A');
         }
@@ -70,6 +71,7 @@ Item {
 
             // Insert new OPERATION_ATTRIBUTES records
             operationId = op_ids["Angler B"];
+            anglerB.operationId = operationId  // #251: set op id for angler QML item, this wont change
             drops.upsertOperationAttribute(operationId, luType, luValue, valueType, value, "Angler B");
             console.info('insert Angler B');
 
@@ -81,6 +83,7 @@ Item {
 
             // Insert new OPERATION_ATTRIBUTES records
             operationId = op_ids["Angler C"];
+            anglerC.operationId = operationId  // #251: set op id for angler QML item, this wont change
             drops.upsertOperationAttribute(operationId, luType, luValue, valueType, value, "Angler C");
             console.info('insert Angler C');
 
@@ -122,12 +125,21 @@ Item {
         }
 
         // TODO - Todd Hay - Update database with new angler name information
-        if (personA !== "")
+        if (personA !== "") {
             drops.upsertOperationAttribute(stateMachine.anglerAOpId, "Angler Attribute", "Angler Name", "alpha", personA, "Angler A");
-        if (personB !== "")
+            anglerA.operationId = stateMachine.anglerAOpId  // #251: setting static op id for angler upon row creation
+            console.debug("Updating operationIDs, angler A: " + stateMachine.anglerAOpId)
+        }
+        if (personB !== "") {
             drops.upsertOperationAttribute(stateMachine.anglerBOpId, "Angler Attribute", "Angler Name", "alpha", personB, "Angler B");
-        if (personC !== "")
+            anglerB.operationId = stateMachine.anglerBOpId  // #251: setting static op id for angler upon row creation
+            console.debug("Updating operationIDs, angler B: " + stateMachine.anglerBOpId)
+        }
+        if (personC !== "") {
             drops.upsertOperationAttribute(stateMachine.anglerCOpId, "Angler Attribute", "Angler Name", "alpha", personC, "Angler C");
+            anglerC.operationId = stateMachine.anglerCOpId  // #251: setting static op id for angler upon row creation
+            console.debug("Updating operationIDs, angler C: " + stateMachine.anglerCOpId)
+        }
         if (personRecorder !== "")
             drops.upsertOperationAttribute(stateMachine.dropOpId, "Drop Attribute", "Recorder Name", "alpha", personRecorder, "Drop " + dropNumber);
     }

--- a/qml/hookandline_hookmatrix/DropsScreen.qml
+++ b/qml/hookandline_hookmatrix/DropsScreen.qml
@@ -84,6 +84,7 @@ Item {
 
                         // Get the JSON angler elements, used to populate the various QML widgets
                         anglerResult = results[drop]["Anglers"][angler];
+                        anglerItem.operationId = anglerResult['id']  // #251: set op id for each angler
                         for (var value in anglerResult) {
                             switch (value) {
                                 case "Angler Time Start":

--- a/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
+++ b/qml/hookandline_hookmatrix/GearPerformanceScreen.qml
@@ -51,7 +51,7 @@ Item {
         title: "Gear Performance: Drop " + stateMachine.drop + " - Angler " + stateMachine.angler
         height: 50
         backwardTitle: "Drops"
-        forwardTitle: drops.getAnglerHooksLabel(anglerOpId)
+        forwardTitle: drops.getAnglerHooksLabel(anglerOpId, true)
         forwardEnabled: drops.isAnglerDoneFishing(anglerOpId)
         forwardVisible: drops.isAnglerDoneFishing(anglerOpId)
     }
@@ -252,9 +252,9 @@ Item {
         btnOkay.text: "Yes"
         btnCancel.text: "No"
         onAccepted: {
+            gearPerformance.undeployAnglerTimes()  // empty time vals to 'UN'; do this first for enabling hooks nav race
             gearPerformance.upsertHooksToUndeployed()  // set all hooks to undeployed
-            gearPerformance.undeployAnglerTimes()  // set all empty time values to 'UN'
-            framHeader.forwardTitle = drops.getAnglerHooksLabel(anglerOpId)  // update Hooks header text
+            framHeader.forwardTitle = drops.getAnglerHooksLabel(anglerOpId, true)  // update Hooks header text
             framHeader.forwardVisible = true  // make nav to hooks visible
             framHeader.forwardEnabled = true  // enable nav to hooks
         }

--- a/qml/hookandline_hookmatrix/HooksScreen.qml
+++ b/qml/hookandline_hookmatrix/HooksScreen.qml
@@ -122,55 +122,71 @@ Item {
         }
         stateMachine.hook = value;
     }
+    function highlightCurrentHook() {
+        // consolidate highlighting logic here
+        currentHook.tfHook.focus = true;
+        currentHook.tfHook.cursorPosition = 0
+        currentHook.tfHook.color = clickedColor
+    }
     function populateHook(species) {
-
     //    if (currentHook == "") return;
-        if (currentHook === null) return;
-
+        if (currentHook === null) {
+            return;
+        }
+        // #144: ask first when gear is undeployed and something other than undeployed is selected
+        if (hooks.isGearUndeployed & species !== 'Undeployed' & currentHook.tfHook.text === 'Undeployed') {
+            dlgGpUndeployed.hookToReview = currentHook;  // hack so dlg can recall this function if we reset to Und
+            dlgGpUndeployed.suggestedSpecies = species;  // passed for info purposes in dlg UI
+            dlgGpUndeployed.open();  // calls back populateHook to reset to Undeployed if rejected
+        }
         hooks.saveHook(currentHook.hookNumber, species);
         switch (currentHook) {
             case hook5:
                 hook5.tfHook.text = species;
                 hook5.tfHook.cursorPosition = 0;
-
-                hook4.tfHook.focus = true;
-                hook4.tfHook.cursorPosition = 0;
-                hook4.tfHook.color = clickedColor;
-
-                currentHook = hook4;
+                currentHook = hook4;  // set current hook to next, then highlight
+                highlightCurrentHook()
                 break;
             case hook4:
                 hook4.tfHook.text = species;
                 hook4.tfHook.cursorPosition = 0;
-
-                hook3.tfHook.focus = true;
-                hook3.tfHook.cursorPosition = 0;
-                hook3.tfHook.color = clickedColor;
                 currentHook = hook3;
+                highlightCurrentHook()
                 break;
             case hook3:
                 hook3.tfHook.text = species;
                 hook3.tfHook.cursorPosition = 0;
-
-                hook2.tfHook.focus = true;
-                hook2.tfHook.cursorPosition = 0;
-                hook2.tfHook.color = clickedColor;
                 currentHook = hook2;
+                highlightCurrentHook()
                 break;
             case hook2:
                 hook2.tfHook.text = species;
                 hook2.tfHook.cursorPosition = 0;
-                hook1.tfHook.focus = true;
-//                hook1.tfHook.selectAll();
-                hook1.tfHook.cursorPosition = 0;
-                hook1.tfHook.color = clickedColor;
                 currentHook = hook1;
+                highlightCurrentHook()
                 break;
             case hook1:
                 hook1.tfHook.text = species;
                 hook1.tfHook.cursorPosition = 0;
                 hook1.tfHook.color = clickedColor;
                 break;
+        }
+    }
+    OkayCancelDialog {
+        // #144: Ask to change to something other than undeployed if GP = undeployed
+        id: dlgGpUndeployed
+        message: '"Undeployed" gear perf. selected.'
+        action: 'Change hook ' + hookToReview.hookNumber + ' from "Undeployed" to "' + suggestedSpecies + '"?'
+        btnOkay.text: "Yes"
+        btnCancel.text: "No"
+        property variant hookToReview;
+        property string suggestedSpecies
+        onAccepted: { // UI seems to unfocus next tf, so re-highlighting next current hook
+            highlightCurrentHook()
+        }
+        onRejected: {  // go back to previous hook and reset to undeployed
+            currentHook = hookToReview  // do this so populateHook write to the correct hook
+            populateHook('Undeployed')
         }
     }
     function getModelSubset(index) {


### PR DESCRIPTION
Changes do the following:

- #251: Assign angler operation id to DropAngler object when they come available, and keep them static
- #247: Use static angler operation id to decide whether Gear Perf nav is allowed from Drops screen
- #144: Allow autopopulate of angler times to undeployed when selecting GP Undeployed
- #144: ask user if GP is undeployed and hook is changed to something else.
