### PR TITLE
FIELD-2100 and 2101:

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+29"
+optecs_version = "2.1.3+30"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+30"
+optecs_version = "2.1.3+31"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverDBMigrations.py
+++ b/py/observer/ObserverDBMigrations.py
@@ -104,6 +104,7 @@ class ObserverDBMigrations(QObject):
 
         #TER flags TODO: remove this migration once all DB files used have these flags
         self.migrate_debriefer_only()  # FIELD-2101
+        self.migrate_status_optecs()  # FIELD-2100
 
         # COMMENTS
         self.migrate_comments()
@@ -259,6 +260,22 @@ class ObserverDBMigrations(QObject):
             self._logger.info(f"Adding column TRIP_CHECKS.DEBRIEFER_ONLY")
         except SQLError as e:
             self._logger.debug(f"TRIP_CHECKS.DEBRIEFER_ONLY col not added; {e}")
+
+    def migrate_status_optecs(self):
+        """
+        FIELD-2100: This column will be in the new versions 2.2, but old databases may be loaded in without
+        This function will add it if missing
+        """
+        try:
+            """
+            NOTE: migrator.add_column not working properly, throws
+                SQLError: table TRIP_CHECKS__tmp__ has no column named CONSTRAINT"
+            migrate(self.migrator.add_column('TRIP_CHECKS', 'STATUS_OPTECS', IntegerField(default=1, null=False)))
+            """
+            database.execute_sql('ALTER TABLE TRIP_CHECKS ADD COLUMN STATUS_OPTECS INTEGER NOT NULL DEFAULT 1')
+            self._logger.info(f"Adding column TRIP_CHECKS.STATUS_OPTECS")
+        except SQLError as e:
+            self._logger.debug(f"TRIP_CHECKS.STATUS_OPTECS col not added; {e}")
 
     def create_hook_counts(self) -> None:
         """

--- a/py/observer/ObserverDBModels.py
+++ b/py/observer/ObserverDBModels.py
@@ -934,7 +934,7 @@ class TripChecks(BaseModel):
                                        to_field='trip_check_group')
     trip_check = PrimaryKeyField(db_column='TRIP_CHECK_ID')
     value_column = TextField(db_column='VALUE_COLUMN', null=True)
-    debriefer_only = IntegerField(db_column='DEBRIEFER_ONLY', null=True)  # FIELD-2101: adding for TER filtering
+    debriefer_only = IntegerField(db_column='DEBRIEFER_ONLY', default=0, null=False)  # FIELD-2101: for TER filtering
 
     class Meta:
         db_table = 'TRIP_CHECKS'

--- a/py/observer/ObserverDBModels.py
+++ b/py/observer/ObserverDBModels.py
@@ -927,6 +927,7 @@ class TripChecks(BaseModel):
     modified_date = TextField(db_column='MODIFIED_DATE', null=True)
     program = IntegerField(db_column='PROGRAM_ID', null=True)
     status = IntegerField(db_column='STATUS')
+    status_optecs = IntegerField(db_column='STATUS_OPTECS', default=1, null=False)  # FIELD-2100: to disable in optecs
     testing_notes = TextField(db_column='TESTING_NOTES', null=True)
     testing_status = TextField(db_column='TESTING_STATUS', null=True)
     trawl_gear_type = IntegerField(db_column='TRAWL_GEAR_TYPE', null=True)

--- a/py/observer/ObserverDBModels.py
+++ b/py/observer/ObserverDBModels.py
@@ -934,6 +934,7 @@ class TripChecks(BaseModel):
                                        to_field='trip_check_group')
     trip_check = PrimaryKeyField(db_column='TRIP_CHECK_ID')
     value_column = TextField(db_column='VALUE_COLUMN', null=True)
+    debriefer_only = IntegerField(db_column='DEBRIEFER_ONLY', null=True)  # FIELD-2101: adding for TER filtering
 
     class Meta:
         db_table = 'TRIP_CHECKS'


### PR DESCRIPTION
See: https://www.fisheries.noaa.gov/jira/browse/FIELD-2100
See: https://www.fisheries.noaa.gov/jira/browse/FIELD-2101

Code changes will allow flag changes in Oracle to sync into Optecs tables.

STATUS_OPTECS flag will disable TERs from running in Optecs at all.  Previously a hard-coded list was used to manually disable TERs that didn't work for various reasons.  We'll now be able to disable from Optecs, OBSPROD, or both.

DEBRIEFER_ONLY flag will allow us to hide TERs from regular users that are only meant for debriefers.

Database files from previous versions should be backwards compatible, adding in fields to TRIP_CHECKS table if missing.