### PR TITLE
FIELD-2123: Add commented fields on data collection method and submitted forms

### DIFF
--- a/py/observer/CountsWeights.py
+++ b/py/observer/CountsWeights.py
@@ -103,6 +103,10 @@ class CountsWeights(QObject):
             self._baskets_model.clear()
         # self.dataExistsChanged.emit()
 
+    @pyqtProperty(bool, notify=unusedSignal)
+    def isPaperEntry(self):
+        return ObserverDBUtil.get_setting('current_collection_method', None) == 'FormsEntryOnly'
+
     @pyqtSlot(name="speciesIsNotCounted", result=bool)
     def _is_mixed_species(self):
         return True if self._current_species_comp_item and \
@@ -606,7 +610,7 @@ class CountsWeights(QObject):
 
             # use subsample avg extrapolation when species avg wt exists, tot basket ct is 0, and subsample ct > thresh
             count_threshold = ObserverDBUtil.get_setting('trawl_subsample_count_threshold', 75)
-            if not self._species_fish_count and self._subsample_avg_weight and self._subsample_count > int(count_threshold):
+            if not self._species_fish_count and self._subsample_avg_weight and self._subsample_count > int(count_threshold) and not self.isPaperEntry:
                 self.subsampleAvgMode = True
             else:
                 self.subsampleAvgMode = False

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+31"
+optecs_version = "2.1.3+32"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+32"
+optecs_version = "2.1.3+33"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.1.3+33"
+optecs_version = "2.1.3+34"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2

--- a/py/observer/ObserverTrip.py
+++ b/py/observer/ObserverTrip.py
@@ -395,7 +395,7 @@ class ObserverTrip(QObject):
         self._current_trip = None
         self._current_trip_model_idx = None
         self.currentCollectionMethod = None
-        self.currentSubmittedForms = None
+        self.currentSubmittedForms = []
         self._tickets_model.clear()
         self._certs_model.clear()
         self._logger.info('Cleared current Trip ID.')

--- a/qml/observer/CountsWeightsScreen.qml
+++ b/qml/observer/CountsWeightsScreen.qml
@@ -835,7 +835,7 @@ Item {
             TableViewColumn {
                 role: "is_subsample"
                 title: "SS"
-                visible: screenCW.speciesIsCounted()
+                visible: screenCW.speciesIsCounted() & !appstate.catches.species.counts_weights.isPaperEntry
                 width: 50
                 delegate: Text {
                     text: styleData.value ? "X" : ""
@@ -1081,6 +1081,7 @@ Item {
 //                    property int widthTF: 100
 
                 RowLayout {
+                    visible: !appstate.catches.species.counts_weights.isPaperEntry
                     anchors.right: parent.right
                     Label {
                         id: lblSubsampleWt
@@ -1112,6 +1113,7 @@ Item {
                     }
                 }
                 RowLayout {
+                    visible: !appstate.catches.species.counts_weights.isPaperEntry
                     anchors.right: parent.right
                     Label {
                         id: lblSubsampleCt
@@ -1144,6 +1146,7 @@ Item {
                     }
                 }
                 RowLayout {
+                    visible: !appstate.catches.species.counts_weights.isPaperEntry
                     anchors.right: parent.right
                     Label {
                         id: lblSubsampleAvg
@@ -1207,7 +1210,7 @@ Item {
                     Layout.preferredWidth: 150
                     Layout.alignment: Qt.AlignHCenter
                     checkable: true
-                    visible: btnEditBasket.checked && screenCW.speciesIsCounted()
+                    visible: btnEditBasket.checked && screenCW.speciesIsCounted() & !appstate.catches.species.counts_weights.isPaperEntry
                     checked: tvBaskets.model.get(tvBaskets.currentRow).is_subsample === 1
                     onClicked: {
                         /*

--- a/qml/observer/EndTripScreen.qml
+++ b/qml/observer/EndTripScreen.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4
+import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2
 import QtQuick.Controls.Private 1.0
 import QtQuick.Controls.Styles 1.4
@@ -77,23 +78,140 @@ Item {
         property int editFontSize: 24
         property int defaultTFHeight: 50    // TextField height default
 
+        Dialog {
+            // FIELD-2123: dialog with checkbox menu for forms to be submitted
+            id: dlgSubmissionForms
+            modality: Qt.ApplicationModal
+            signal dialogClosed;
+            width: 325
+            height: 540
+            title: "Submitted Forms"
+            contentItem: Rectangle {
+                color: "lightgray"
+                border.color: "black"  // using windowless hint flag, so setting border
+                border.width: 6
+                anchors.fill: parent
+                ColumnLayout {
+                    id: clCboxes
+                    ColumnLayout {
+                        Label {
+                            text: "Forms to be submitted:"
+                            font.pixelSize: 20
+                            Layout.leftMargin: 20
+                            Layout.bottomMargin: 10
+                            Layout.topMargin: 20
+                        }
+                        /*
+                        Signalling logic
+                        1. Do nothing until "Save" button
+                        2. On save append checked dbStrs to array and set appstate.trips.currentSubmittedForms
+                        3. if appstate.trips.currentSubmittedForms changed, emit back string onSubmittedFormsChanged
+                        4. upsert string as comment using prefix
+                        */
+                        Repeater {
+                            id: rptFormChecks
+                            model: [
+                                "MM/SB/ST Forms",
+                                "BRD/HFLC Forms",
+                                "Deck Sheet",
+                                "Vessel Logbook Images",
+                                "Species ID Forms",
+                                "IFQ Tracking Form",
+                                "Scrap Paper",
+                                "Other",
+                                "None"
+                            ]
+                            ObserverCheckBox {
+                                text: modelData
+                                property string dbStr: modelData.split("/").join("").split(" ").join("")
+                                checkbox_size: 40
+                                Layout.alignment: Qt.AlignLeft
+                                Layout.leftMargin: 40
+                                checked: appstate.trips.currentSubmittedForms.indexOf(dbStr) > -1
+                                onCheckedChanged: {
+                                    // logic to uncheck everything if None checked
+                                    if (checked & modelData === 'None') {
+                                        for (var i = 0; i < rptFormChecks.model.length; i++) {
+                                            var cbox = rptFormChecks.itemAt(i)
+                                            if (cbox.text !== 'None' & cbox.checked) {
+                                                cbox.checked = false;
+                                            }
+                                        }
+                                    // uncheck None if anything else checked
+                                    } else if (checked) {
+                                        var noneBox = rptFormChecks.itemAt(rptFormChecks.model.indexOf('None'))
+                                        if (noneBox) {noneBox.checked = false}
+                                    }
+                                }
+                            }
+                            function getSelectedForms() {
+                                var checklist = [];
+                                for (var i = 0; i < model.length; i++) {
+                                    var cbox = rptFormChecks.itemAt(i)
+                                    if (cbox.checked) {
+                                        checklist.push(cbox.dbStr)
+                                    }
+                                }
+                                return checklist
+                            }
+                        }
+                    }
+                    RowLayout {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        ObserverSunlightButton{
+                            id: btnSubmitForms
+                            text: "Save"
+                            anchors.centerIn: parent
+                            Layout.topMargin: 20
+                            Layout.preferredWidth: 100
+                            Layout.preferredHeight: 50
+                            onClicked: {
+                                dlgSubmissionForms.close()
+                                appstate.trips.currentSubmittedForms = rptFormChecks.getSelectedForms()
+                            }
+                        }
+                    }
+                }
+                Connections {
+                    target: appstate.trips
+                    onSubmittedFormsChanged: {
+                        appstate.upsertComment(
+                            appstate.trips.FORMS_SUBMISSION_PREFIX,
+                            forms + ";",
+                            obsSM.currentStateName + "::End Trip"
+                        )
+                    }
+                }
+            }
+            onVisibleChanged: {
+                if (visible) {
+                    contentItem.ApplicationWindow.window.flags |= Qt.FramelessWindowHint
+                }
+            }
+        }
         RowLayout {
-
             ObserverCheckBox {
                 id: checkPartialTrip
                 text: "Partial Trip"
                 checkbox_size: 40
-                Layout.fillWidth: true
+//                Layout.fillWidth: true
                 checked: appstate.trips.getData("partial_trip")
                 onCheckedChanged: {
                     appstate.trips.setData("partial_trip", checked);
                 }
             }
-            Rectangle { // spacer
-                color: "transparent"
-                Layout.preferredWidth: 10
+            ObserverSunlightButton {
+                id: btnSubmissionForms
+                width: 100
+                Layout.leftMargin: 50
+                Layout.rightMargin: 50
+                Layout.preferredWidth: 150
+                text: "Forms to\nSubmit"
+                onClicked: {
+                    dlgSubmissionForms.open()
+                }
             }
-
             Label {
                 text: "Fish Processed\nDuring Trip"
                 font.pixelSize: 20

--- a/qml/observer/EndTripScreen.qml
+++ b/qml/observer/EndTripScreen.qml
@@ -204,6 +204,9 @@ Item {
             ObserverSunlightButton {
                 id: btnSubmissionForms
                 width: 100
+                // FIELD-2123: underline/bold if nothing has been selected yet
+                txtBold: appstate.trips.currentSubmittedForms.length === 0
+                txtUnderline: appstate.trips.currentSubmittedForms.length === 0
                 Layout.leftMargin: 50
                 Layout.rightMargin: 50
                 Layout.preferredWidth: 150

--- a/qml/observer/ObserverFooterRow.qml
+++ b/qml/observer/ObserverFooterRow.qml
@@ -157,7 +157,7 @@ RowLayout {
             font.pixelSize: defaultPixelSize
             width: defaultitemwidth
             visible: false
-
+            enabled: appstate.trips.currentSubmittedForms.length > 0  // FIELD-2123: only if submitted forms selected
             MouseArea {
                 anchors.fill: parent
                 onClicked: {

--- a/qml/observer/ObserverSunlightButton.qml
+++ b/qml/observer/ObserverSunlightButton.qml
@@ -18,7 +18,7 @@ Button {
     property string bgColor: "lightgray"
     property string highlightColor: "white"
     property int fontsize: 20
-
+    property bool txtUnderline: false  // FIELD-2123: underline text if button is required field(s)
     property bool txtBold: false
 
     style: ButtonStyle {
@@ -30,6 +30,7 @@ Button {
             font.pixelSize: fontsize
             color: txtColor
             font.bold: txtBold
+            font.underline: txtUnderline
             text: control.text
         }
         background: Rectangle {

--- a/qml/observer/TripDetailsFGScreen.qml
+++ b/qml/observer/TripDetailsFGScreen.qml
@@ -677,7 +677,7 @@ Item {
                                     obsSM.currentStateName + "::Trip Details"
                                 )
                                 if (method === 'FormsEntryOnly') {
-                                    framFooter.openComments("DeckFormsOnly:")
+                                    framFooter.openComments("")
                                 }
                             }
                         }

--- a/qml/observer/TripDetailsFGScreen.qml
+++ b/qml/observer/TripDetailsFGScreen.qml
@@ -39,9 +39,14 @@ Item {
         if (!fisheryIsSpecified) {
             console.debug("Trip's fishery not yet specified.");
         }
+        // FIELD-2123: collection method required
+        var collectionMethodChecked = (grpCollectionMethod.current)
+        if (!collectionMethodChecked) {
+            console.debug("Collection Method not checked!")
+        }
 
         // Update navigation
-        var detailsComplete = vesselIsSpecified && fisheryIsSpecified;
+        var detailsComplete = vesselIsSpecified && fisheryIsSpecified && collectionMethodChecked;
         framHeader.forwardEnable(detailsComplete);
 
         // Update highlights of labels of required field
@@ -616,8 +621,81 @@ Item {
                 readOnly: true;
             }
         }
-    } // GridLayout
 
+        RowLayout {
+            // FIELD-2123: Menu to select type of catch data entry.  Required to advance to sets
+            visible: (tfFishery.text.length > 0 & tfVesselName.length > 0)
+            Label {
+                id: lblCollectionMethod
+                text: qsTr("Catch Collection\nMethod")
+                Layout.preferredWidth: gridStartTrip.labelColWidth
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: 25
+            }
+            RowLayout {
+                ExclusiveGroup {
+                    id: grpCollectionMethod
+                    onCurrentChanged: {
+                        checkDetailsComplete()
+                    }
+                }
+                Repeater {
+                    model: [
+                        'Direct\nOnly',
+                        'Direct/Form\nHybrid',
+                        'Forms\nOnly'
+                    ]
+                    ObserverGroupButton {
+                        text: modelData
+                        property string dbStr: modelData.replace("\n", "").replace("/", "")  // strip for db comment
+                        exclusiveGroup: grpCollectionMethod
+                        Layout.preferredWidth: 120
+                        Layout.preferredHeight: ObserverSettings.default_tf_height
+//                        enabled: (tfFishery.text.length > 0 & tfVesselName.length > 0)
+                        checked: appstate.trips.currentCollectionMethod === dbStr  // send flatstr between py and qml
+                        /*
+                        1. set currentCollectionMethod
+                        2. if val has changed, emit python signal collectionMethodChanged
+                        3. Use stateMachine.upsertComment with emitted value to upsert comment
+                        */
+                        onClicked: {
+                            if (checked) {
+                                appstate.trips.currentCollectionMethod = dbStr
+                            }
+                            checkDetailsComplete()
+                        }
+                        Connections {
+                            target: appstate.trips
+                            onCollectionMethodChanged: {
+                                appstate.upsertComment(
+                                    appstate.trips.COLLECTION_METHOD_PREFIX,
+                                    method + ';'
+                                    , "start_fg_state::Trip Details"
+                                )
+                                if (method === 'FormsOnly') {
+                                    framFooter.openComments("DeckFormsOnly:")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Label{}
+            Label {
+                id: lblDeckFormReminder
+                text: (
+                      appstate.trips.currentCollectionMethod == 'FormsOnly' ||
+                      appstate.trips.currentCollectionMethod == 'DirectFormHybrid'
+                ) ? "Attach PDF(s) at trip end" : ""
+                Layout.preferredWidth: gridStartTrip.labelColWidth
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: 18
+                color: "red"
+            }
+        }
+    } // GridLayout
     Rectangle {
      id: keyboardFrame // add a background for the autocomplete dropdown
      color: ObserverSettings.default_bgcolor

--- a/qml/observer/TripDetailsScreen.qml
+++ b/qml/observer/TripDetailsScreen.qml
@@ -52,6 +52,7 @@ Item {
         // Update highlights of labels of required field
         vesselLabel.highlight(!vesselIsSpecified);
         fisheryLabel.highlight(!fisheryIsSpecified);
+        lblCollectionMethod.highlight(!collectionMethodChecked);
     }
 
     Keys.forwardTo: [framNumPadDetails, keyboardMandatory] // Required for capture of Enter key
@@ -599,79 +600,82 @@ Item {
                     appstate.trips.currentStartPortName = text;
                 }
             }
+        }
+        RowLayout {
+            // FIELD-2123: Menu to select type of catch data entry.  Required to advance to hauls
+            visible: (tfFishery.text.length > 0 & tfVesselName.length > 0)
+            FramLabelHighlightCapable {
+                id: lblCollectionMethod
+                text: qsTr("Catch Collection\nMethod")
+                Layout.preferredWidth: gridStartTrip.labelColWidth
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: 25
+            }
             RowLayout {
-                // FIELD-2123: Menu to select type of catch data entry.  Required to advance to hauls
-                visible: (tfFishery.text.length > 0 & tfVesselName.length > 0)
-                Label {
-                    id: lblCollectionMethod
-                    text: qsTr("Catch Collection\nMethod")
-                    Layout.preferredWidth: gridStartTrip.labelColWidth
-                    Layout.fillHeight: true
-                    verticalAlignment: Text.AlignVCenter
-                    font.pixelSize: 25
+                ExclusiveGroup {
+                    id: grpCollectionMethod
+                    onCurrentChanged: {
+                        checkDetailsComplete()
+                    }
                 }
-                RowLayout {
-                    ExclusiveGroup {
-                        id: grpCollectionMethod
-                        onCurrentChanged: {
+                Repeater {
+                    model: [
+                        'Direct\nEntry\nOnly',
+                        'Direct\nForm\nHybrid',
+                        'Forms\nEntry\nOnly'
+                    ]
+                    ObserverGroupButton {
+                        text: modelData
+                        property string dbStr: modelData.split("\n").join("")  // strip for db comment; replaceAll DNE
+                        exclusiveGroup: grpCollectionMethod
+                        Layout.preferredWidth: 80
+                        Layout.preferredHeight: 80
+//                        enabled: (tfFishery.text.length > 0 & tfVesselName.length > 0)
+                        checked: appstate.trips.currentCollectionMethod === dbStr  // send flatstr between py and qml
+                        /*
+                        1. set currentCollectionMethod
+                        2. if val has changed, emit python signal collectionMethodChanged
+                        3. Use stateMachine.upsertComment with emitted value to upsert comment
+                        */
+                        onClicked: {
+                            if (checked) {
+                                appstate.trips.currentCollectionMethod = dbStr
+                            }
                             checkDetailsComplete()
                         }
-                    }
-                    Repeater {
-                        model: [
-                            'Direct\nOnly',
-                            'Direct/Form\nHybrid',
-                            'Forms\nOnly'
-                        ]
-                        ObserverGroupButton {
-                            text: modelData
-                            property string dbStr: modelData.replace("\n", "").replace("/", "")  // strip for db comment
-                            exclusiveGroup: grpCollectionMethod
-                            Layout.preferredWidth: 120
-                            Layout.preferredHeight: ObserverSettings.default_tf_height
-    //                        enabled: (tfFishery.text.length > 0 & tfVesselName.length > 0)
-                            checked: appstate.trips.currentCollectionMethod === dbStr  // send flatstr between py and qml
-                            /*
-                            1. set currentCollectionMethod
-                            2. if val has changed, emit python signal collectionMethodChanged
-                            3. Use stateMachine.upsertComment with emitted value to upsert comment
-                            */
-                            onClicked: {
-                                if (checked) {
-                                    appstate.trips.currentCollectionMethod = dbStr
-                                }
-                                checkDetailsComplete()
-                            }
 
-                            Connections {
-                                target: appstate.trips
-                                onCollectionMethodChanged: {
-                                    appstate.upsertComment(
-                                        appstate.trips.COLLECTION_METHOD_PREFIX,
-                                        method + ';'
-                                        , "start_trawl_state::Trip Details"
-                                    )
-                                    if (method === 'FormsOnly') {
-                                        framFooter.openComments("DeckFormsOnly:")
-                                    }
+                        Connections {
+                            target: appstate.trips
+                            onCollectionMethodChanged: {
+                                //TODO: Why is this signal emitted once but run 3 times here?
+                                appstate.upsertComment(
+                                    appstate.trips.COLLECTION_METHOD_PREFIX,
+                                    method + ';',
+                                    obsSM.currentStateName + "::Trip Details"
+                                )
+                                if (method === 'FormsEntryOnly') {
+                                    framFooter.openComments("DeckFormsOnly:")
                                 }
                             }
                         }
                     }
                 }
-                Label{}
-                Label {
-                    id: lblDeckFormReminder
-                    text: (
-                          appstate.trips.currentCollectionMethod == 'FormsOnly' ||
-                          appstate.trips.currentCollectionMethod == 'DirectFormHybrid'
-                    ) ? "Attach PDF(s) at trip end" : ""
-                    Layout.preferredWidth: gridStartTrip.labelColWidth
-                    Layout.fillHeight: true
-                    verticalAlignment: Text.AlignVCenter
-                    font.pixelSize: 18
-                    color: "red"
-                }
+            }
+        }
+        RowLayout {
+            Label{}
+            Label {
+                id: lblDeckFormReminder
+                text: (
+                      appstate.trips.currentCollectionMethod == 'FormsEntryOnly' ||
+                      appstate.trips.currentCollectionMethod == 'DirectFormHybrid'
+                ) ? "Attach PDF(s) at trip end" : ""
+                Layout.preferredWidth: gridStartTrip.labelColWidth
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignVCenter
+                font.pixelSize: 18
+                color: "red"
             }
         }
     } // GridLayout

--- a/qml/observer/TripDetailsScreen.qml
+++ b/qml/observer/TripDetailsScreen.qml
@@ -655,7 +655,7 @@ Item {
                                     obsSM.currentStateName + "::Trip Details"
                                 )
                                 if (method === 'FormsEntryOnly') {
-                                    framFooter.openComments("DeckFormsOnly:")
+                                    framFooter.openComments("")
                                 }
                             }
                         }


### PR DESCRIPTION
Users will now be required to enter how they're collecting data (direct, direct/form hybrid, forms transcription only) on the Trip Details page.  They'll also be required to enter which forms will be uploaded/submitted on the End Trip page.  These values will be written to the notes field.

The daily avg trawl count feature will be disabled if "Forms Only" collection method is selected.

See: https://www.fisheries.noaa.gov/jira/browse/FIELD-2123