### PR TITLE
CutterStation Length/Weight relationship check branch merged to dev

### DIFF
--- a/py/survey_backdeck/FishSampling.py
+++ b/py/survey_backdeck/FishSampling.py
@@ -529,8 +529,36 @@ class FishSampling(QObject):
         self._specials_model = SpecialsModel(app=self._app, db=self._db)
         self._species_full_list_model = SpeciesFullListModel(app=self._app)
         self._personnel_model = PersonnelModel(app=self._app)
+        self._current_specimen_index = None
+        self._current_specimen = None
 
         self._random_drops = None
+
+    @pyqtProperty(int)
+    def currentSpecimenIndex(self):
+        return self._current_specimen_index
+
+    @currentSpecimenIndex.setter
+    def currentSpecimenIndex(self, ix):
+        """
+        Set when user selects row from FishSampling tableview.
+        Use to set current specimen model so we get most updated data from self._specimens_model
+        :param ix: int, model index
+        """
+        self._current_specimen_index = ix
+
+    @property
+    def current_specimen(self):
+        """
+        Always pull current specimen using current index, so we're always
+        accessing updated model data
+        :return: SpecimensModel object
+        """
+        ix = self._current_specimen_index
+        if ix is None or ix < 0 or ix >= self._specimens_model.count:
+            self._current_specimen = None
+        else:
+            return self._specimens_model.get(ix)
 
     @pyqtProperty(FramListModel, notify=personnelModelChanged)
     def personnelModel(self):

--- a/qml/survey_backdeck/FishSamplingEntryDialog.qml
+++ b/qml/survey_backdeck/FishSamplingEntryDialog.qml
@@ -195,6 +195,7 @@ Dialog {
 
         if ("specimenID" in specimen) {
             specimenID = specimen["specimenID"];
+            fishSampling.currentSpecimenId = specimenID  // #94: set for FishSampling class
             for (var item in specimen) {
                 if (specimen[item] !== undefined) {
 //                    console.info('populating ' + item);

--- a/qml/survey_backdeck/FishSamplingEntryDialog.qml
+++ b/qml/survey_backdeck/FishSamplingEntryDialog.qml
@@ -99,6 +99,10 @@ Dialog {
     Connections {
         target: fishSampling
         onExceptionEncountered: showException(message, action);
+        onLwRelationshipOutlier: {  // 94: when LW outlier message received, display in dialog
+            dlgLwWarning.message = message
+            dlgLwWarning.open()
+        }
     } // fishSampling.onExceptionEncountered
     function showException(message, action) {
         dlgOkay.message = message;
@@ -605,6 +609,11 @@ Dialog {
                     actionSubType = actionSubType ? actionSubType.replace("\n", " ") : null;
                     fishSampling.upsertObservation(specimenID, action, value, dataType,
                                                     actionSubType, speciesSamplingPlanId);
+
+                    // # 94: check LW relationship when sex/length/weight changes
+                    if (action === 'sex' || action === 'length' || action === 'weight') {
+                        fishSampling.checkLWRelationship()
+                    }
                     break;
             }
         }
@@ -897,6 +906,32 @@ Dialog {
     OkayDialog {
         id: dlgOkay
         modality: Qt.ApplicationModal
+    }
+    LengthWeightDialog {
+        // #94: LW dialog to pop with message
+        id: dlgLwWarning
+        message: ""
+        onProceed: {  // do nothing, go to age tab
+            tbActions.setCurrentIndex(5)
+            dlgLwWarning.close()
+        }
+        onProceedWNote: {  // do nothing, open note dialog
+            tbActions.setCurrentIndex(5)
+            dlgLwWarning.close()
+            dlgDrawingNotes.open()
+        }
+        onEditWeight: {  // back to weight tab
+            tbActions.setCurrentIndex(2)
+            dlgLwWarning.close()
+        }
+        onEditLength: {  // back to length tab
+            tbActions.setCurrentIndex(3)
+            dlgLwWarning.close()
+        }
+        onEditSex: {  // back to sex tab
+            tbActions.setCurrentIndex(4)
+            dlgLwWarning.close()
+        }
     }
     SpeciesConflictDialog {
         id: dlgSpeciesConflict

--- a/qml/survey_backdeck/FishSamplingScreen.qml
+++ b/qml/survey_backdeck/FishSamplingScreen.qml
@@ -343,7 +343,6 @@ Item {
             selection.onSelectionChanged: {
                 if (currentRow != -1) {
                     if (tvSpecimens.selection.contains(currentRow)) {
-                        fishSampling.currentSpecimenIndex = currentRow  // #94: pass index, grab selected specimen
                         var currentAdh = fishSampling.specimensModel.get(currentRow).adh;
                         if ((currentAdh !== undefined) && (currentAdh.length === 3)) {
                             stateMachine.angler = currentAdh.charAt(0);

--- a/qml/survey_backdeck/FishSamplingScreen.qml
+++ b/qml/survey_backdeck/FishSamplingScreen.qml
@@ -343,6 +343,7 @@ Item {
             selection.onSelectionChanged: {
                 if (currentRow != -1) {
                     if (tvSpecimens.selection.contains(currentRow)) {
+                        fishSampling.currentSpecimenIndex = currentRow  // #94: pass index, grab selected specimen
                         var currentAdh = fishSampling.specimensModel.get(currentRow).adh;
                         if ((currentAdh !== undefined) && (currentAdh.length === 3)) {
                             stateMachine.angler = currentAdh.charAt(0);

--- a/qml/survey_backdeck/LengthWeightDialog.qml
+++ b/qml/survey_backdeck/LengthWeightDialog.qml
@@ -14,9 +14,9 @@ import QtQuick.Window 2.0
 Dialog {
     id: dlg
     width: 580
-    height: 580
+    height: 500
     modality: Qt.ApplicationModal  // force acknowledgement here before going elsewhere
-    title: "L-W Relationship Warning"
+    title: "LW Relationship Warning!"
 
     property string message: ""
 

--- a/qml/survey_backdeck/LengthWeightDialog.qml
+++ b/qml/survey_backdeck/LengthWeightDialog.qml
@@ -1,0 +1,111 @@
+/*****************************************************************************
+Custom dialog created for #94 length weight relationship warning check
+
+******************************************************************************/
+
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.0
+
+//import "../common"
+
+Dialog {
+    id: dlg
+    width: 580
+    height: 580
+    modality: Qt.ApplicationModal  // force acknowledgement here before going elsewhere
+    title: "L-W Relationship Warning"
+
+    property string message: ""
+
+    signal proceed
+    signal proceedWNote
+    signal editSex
+    signal editWeight
+    signal editLength
+
+    // signal actions defined in FishSamplingEntryDialog.qml
+    onRejected: {  }
+    onAccepted: {  }
+    onProceed: {  }
+    onProceedWNote: {  }
+    onEditSex: {  }
+    onEditWeight: {  }
+    onEditLength: {  }
+
+    contentItem: Rectangle {
+        color: "#eee"
+        RowLayout {
+            id: rwlMsg
+            anchors.left: parent.left
+            Label {
+                id: lblMessage
+                anchors.left: parent.left
+                horizontalAlignment: Text.AlignCenter
+                text: message
+                font.pixelSize: 20
+            } // lblMessage
+        }
+        RowLayout {
+            id: rwlContinue
+            anchors.top: rwlMsg.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 20
+            BackdeckButton {
+                id: btnContinue
+                text: "Proceed\nto Age"
+                Layout.preferredWidth: this.width
+                Layout.preferredHeight: this.height
+                onClicked: { dlg.proceed() }
+            }
+            BackdeckButton {
+                id: btnContinueWNote
+                text: "Proceed w.\nnote"
+                Layout.preferredWidth: this.width
+                Layout.preferredHeight: this.height
+                onClicked: { dlg.proceedWNote() }
+            }
+        }
+        RowLayout {
+            id: rwlEdits
+            Layout.fillHeight: false
+            anchors.top: rwlContinue.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: 20
+            BackdeckButton {
+                id: btnEditWeight
+                text: "Edit\nWeight"
+                Layout.topMargin: 20
+                Layout.preferredWidth: this.width
+                Layout.preferredHeight: this.height
+                onClicked: { dlg.editWeight() }
+            }
+            BackdeckButton {
+                id: btnEditLength
+                text: "Edit\nLength"
+                Layout.topMargin: 20
+                Layout.preferredWidth: this.width
+                Layout.preferredHeight: this.height
+                onClicked: { dlg.editLength() }
+            }
+            BackdeckButton {
+                id: btnEditSex
+                text: "Edit\nSex"
+                Layout.topMargin: 20
+                Layout.preferredWidth: this.width
+                Layout.preferredHeight: this.height
+                onClicked: { dlg.editSex() }
+            }
+        } // rwlEdits
+
+
+
+//        Keys.onPressed: if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) dlg.click(StandardButton.Retry)
+        Keys.onEnterPressed: dlg.proceed()
+        Keys.onReturnPressed: dlg.proceed()
+        Keys.onEscapePressed: dlg.proceed()
+        Keys.onBackPressed: dlg.proceed() // especially necessary on Android
+    }
+}

--- a/qrc/survey_backdeck.qrc
+++ b/qrc/survey_backdeck.qrc
@@ -42,6 +42,7 @@
         <file>../qml/survey_backdeck/DrawingNotesDialog.qml</file>
         <file>../qml/survey_backdeck/SpeciesConflictDialog.qml</file>
         <file>../qml/survey_backdeck/RecordedByDialog.qml</file>
+        <file>../qml/survey_backdeck/LengthWeightDialog.qml</file>
 
         <!-- Images -->
         <file>../resources/images/navigation_previous_item_dark.png</file>


### PR DESCRIPTION
Length/Weight relationship check now implemented per issue #94.  Steps Cutter Station goes through:

1. Set current_specimen property value in FishSampling.py using specimenID var from FishSamplingEntryDialog.qml
2. Pull length, weight, and sex from this current specimen
3. Pull LW coefficient (a) and exponent (b) from LENGTH_WEIGHT_RELATIONSHIP_LU table in hookandline_fpc.db
4. Pull tolerance value from SETTINGS table
5. Are either length or weight not filled, but sex is? warn user
6. Do we have all the LW params filled? Predict weight with W = aL^b and apply tolerance range.  Does weight fall within bounds? If not, warn user.