### PR TITLE
#259: Cutter Station settings page initial commit

### DIFF
--- a/main_survey_backdeck.py
+++ b/main_survey_backdeck.py
@@ -45,6 +45,7 @@ from py.survey_backdeck.StateMachine import StateMachine
 from py.survey_backdeck.SerialPortManager import SerialPortManager
 from py.survey_backdeck.LabelPrinter import LabelPrinter
 from py.survey_backdeck.Notes import Notes
+from py.survey_backdeck.Settings import Settings
 
 import py.survey_backdeck.survey_backdeck_qrc
 
@@ -120,6 +121,7 @@ class Backdeck:
         self.label_printer = LabelPrinter(app=self, db=db)
         self.notes = Notes(app=self, db=db)
         # self.qaqc = QAQC(app=self, db=db)
+        self.settings = Settings(app=self, db=db)
 
         self.context.setContextProperty("soundPlayer", self.sound_player)
         self.context.setContextProperty("stateMachine", self.state_machine)
@@ -129,6 +131,7 @@ class Backdeck:
         self.context.setContextProperty("labelPrinter", self.label_printer)
         self.context.setContextProperty("notes", self.notes)
         # self.context.setContextProperty("qaqc", self.qaqc)
+        self.context.setContextProperty("settings", self.settings)
 
         # self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 

--- a/py/survey_backdeck/StateMachine.py
+++ b/py/survey_backdeck/StateMachine.py
@@ -506,6 +506,11 @@ class StateMachine(QObject):
         self._angler_name = value
         self.anglerNameSelected.emit()
 
+    @pyqtSlot(name="exitApp")
+    def exitApp(self):
+        logging.info("Calling exitApp to quit app")
+        exit()
+
 if __name__ == '__main__':
 
     sm = StateMachine()

--- a/qml/survey_backdeck/BackdeckStateMachine.qml
+++ b/qml/survey_backdeck/BackdeckStateMachine.qml
@@ -8,17 +8,19 @@ DSM.StateMachine {
     // Aliases to various states
     property alias sites_state: sites_state
     property alias fish_sampling_state: fish_sampling_state
+    property alias settings_state: settings_state
 
     // Signals for transitioning to the different screens/states
     signal to_sites_state
     signal to_fish_sampling_state
+    signal to_settings_state
 
     DSM.State {
         id: sites_state
         onEntered: {
             stateMachine.previousScreen = stateMachine.screen;
             stateMachine.screen = "sites";
-            if (stateMachine.previousScreen === "fishsampling") {
+            if (stateMachine.previousScreen === "fishsampling" || stateMachine.previousScreen == 'settings') {
                 if (screens.busy) return;
                 screens.pop();
             }
@@ -26,6 +28,10 @@ DSM.StateMachine {
         DSM.SignalTransition {
             targetState: fish_sampling_state
             signal: to_fish_sampling_state
+        } // to_haul_selection_state
+        DSM.SignalTransition {
+            targetState: settings_state
+            signal: to_settings_state
         } // to_haul_selection_state
     } // sites_state
     DSM.State {
@@ -45,4 +51,16 @@ DSM.StateMachine {
             signal: to_sites_state
         }
     } // fish_sampling_state
+    DSM.State {
+        id: settings_state
+        onEntered: {
+            stateMachine.previousScreen = stateMachine.screen;
+            stateMachine.screen = "settings";
+            screens.push(Qt.resolvedUrl("SettingsScreen.qml"));
+        }
+        DSM.SignalTransition {
+            targetState: sites_state
+            signal: to_sites_state
+        } // back to_sites_state
+    } // settings_state
 }

--- a/qml/survey_backdeck/SettingsScreen.qml
+++ b/qml/survey_backdeck/SettingsScreen.qml
@@ -1,0 +1,225 @@
+
+/*************************************************************************
+Created by:     Jim Fellows (james.fellows@noaa.gov)
+Created date:   20210908
+
+Description:    Expose all parameters of Setting table to UI
+                to allow user to manipulate for current vessel.  TableView
+                can be edited via loaded delegate or via "Restore Defaults"
+                button, which pulls settings from "DEFAULT_SETTINGS" table.
+                Settings changes are not allowed with collected data in database.
+                "Clean DB" functionality exists to allow user to clear out collected
+                data.
+
+**************************************************************************/
+
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Controls.Styles 1.1
+import QtQuick.Layouts 1.2
+
+import "../common"
+
+// TODO: consolidate this into a single QML widget in COMMON to share with HookMatrix
+
+Item {
+    Component.onDestruction: {
+        smBackdeck.to_sites_state()
+    }
+    ColumnLayout {  // layout for entire
+        anchors.fill: parent
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        anchors.topMargin: 10
+        anchors.bottomMargin: 10
+
+        RowLayout {
+            id: rlTable
+            TrawlBackdeckTableView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                // editable tableview: https://stackoverflow.com/questions/43273240/how-to-make-a-cell-editable-in-qt-tableview
+                // review this thread to understand how to update model
+                // https://www.qtcentre.org/threads/68074-Tabview-update-after-the-model-data-changes
+
+                id: tvSettings
+                model: settings.model
+                horizontalScrollBarPolicy: -1
+                selectionMode: SelectionMode.SingleSelection
+
+                TableViewColumn {
+                    id: colParameter
+                    title: "Parameter"
+                    role: "parameter"
+                    movable: false
+                    resizable: false
+                    width: tvSettings.viewport.width - colNewValue.width - colCurValue.width
+                }
+                TableViewColumn {
+                    id: colCurValue
+                    title: "Current Value"
+                    role: "value"
+                    movable: false
+                    resizable: false
+                    width: tvSettings.viewport.width / 3
+                }
+                TableViewColumn {
+                    id: colNewValue
+                    title: "New Value"
+                    role: "value"
+                    movable: false
+                    resizable: false
+                    width: tvSettings.viewport.width / 3
+                }
+
+                itemDelegate: Rectangle {
+                    Text {
+                        anchors { verticalCenter: parent.verticalCenter; left: parent.left }
+                        color: "black"
+                        text: styleData.value
+                        font.pixelSize: 18
+                    }
+
+                    MouseArea {
+                        id: cellMouseArea
+                        anchors.fill: parent
+                        onClicked: {
+                            if (styleData.column === 2) {  // only allow new val col for edits
+                                loader.visible = true
+                                loader.item.forceActiveFocus()
+                            }
+                        }
+                    }
+                    Loader {
+                        id: loader
+                        anchors { verticalCenter: parent.verticalCenter; left: parent.left}
+                        height: parent.height
+                        width: parent.width
+                        visible: false
+                        sourceComponent: visible ? input : undefined
+                        Component {
+                            id: input
+                            TextField {
+                                anchors { fill: parent }
+                                text: ""
+                                font.pixelSize: 18
+                                textColor: "Green"
+                                onAccepted:{
+                                    if (styleData.value !== text) {
+                                        console.info("Parameter " + model.parameter + " being set to " + text + " from " + styleData.value)
+                                        dlgUpdateParam.confirm(model.parameter, text, styleData.value)
+                                    }
+                                    loader.visible = false
+                                }
+                                onActiveFocusChanged: {
+                                    if (!activeFocus) {
+                                        loader.visible = false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                OkayCancelDialog {
+                    id: dlgUpdateParam
+                    message: ""
+                    property string param: "";
+                    property string oldVal: "";
+                    property string newVal: "";
+
+                    height: 250
+                    width: 700
+
+                    function confirm(p, nv, ov) {
+                        param = p;
+                        newVal = nv;
+                        oldVal = ov;
+                        // TODO move this outside to actual value change
+                        dlgUpdateParam.message = 'Changing "' + param + '":\n\n"' + oldVal + '" --> "' + newVal + '"\n'
+                        dlgUpdateParam.open()
+                    }
+                    onAccepted: {
+                        settings.updateDbParameter(param, newVal, oldVal)  // this func updates db and model
+                    }
+                }
+            }
+        }
+        RowLayout {  //row for buttons along bottom of table
+            id: rlButtons
+            anchors.right: parent.right
+            anchors.left: parent.left
+            TrawlBackdeckButton {
+                anchors.left: parent.left
+                text: qsTr("<<")
+                implicitHeight: 60
+                implicitWidth: 100
+                onClicked: smBackdeck.to_sites_state()
+            }
+            RowLayout {
+                anchors.horizontalCenter: parent.horizontalCenter
+                TrawlBackdeckButton {
+                    id: btnRestore
+                    text: qsTr("Restore\nDefaults")
+
+                    implicitHeight: 60
+                    onClicked: {
+                        dlgDefaults.ask()
+                    }
+                    OkayCancelDialog {
+                        id: dlgDefaults
+                        title: "Restore Settings"
+                        message: ""
+                        function ask() {
+                            message = "Restoring default settings\nfor " + cbVessels.currentText + " vessel"
+                            dlgDefaults.open()
+                        }
+                        onAccepted: {
+                            // TODO: Create DEFAULT_SETTINGS table to pull these from
+                            var vesselName = cbVessels.currentText;
+                            var paramName = 'FPC IP Address'
+                            var fpcIp;
+                            switch (vesselName) {
+                                case 'Aggressor':
+                                    fpcIp = '192.254.241.5';
+                                    break;
+                                case 'Mirage':
+                                    fpcIp = '192.254.242.5';
+                                    break;
+                                case 'Toronado':
+                                    fpcIp = '192.254.243.5';
+                                    break
+                                default:
+                                    fpcIp = '192.254.241.5';
+                                    break
+                            }
+                            settings.updateDbParameter(paramName, fpcIp)  // this func updates db and model
+                        }
+                    }
+                }
+                FramComboBox {
+                    // TODO: Pull these from DEFAULT_SETTINGS table
+                    id: cbVessels
+                    model: ['Mirage', 'Aggressor', 'Toronado']
+                    implicitWidth: 250
+                    implicitHeight: 60
+                }
+            }
+        }
+    }
+    OkayDialog {
+        // message when killing app during reboot
+        id: dlgReboot
+        message: ""
+        onAccepted: {
+            stateMachine.exitApp()
+        }
+            Connections {
+                target: settings
+                onRebootRequired: {
+                    dlgReboot.message = param + " value has changed"
+                    dlgReboot.action = "Cutter Station reboot required."
+                    dlgReboot.open()
+                }
+            }
+    }
+}

--- a/qml/survey_backdeck/SitesScreen.qml
+++ b/qml/survey_backdeck/SitesScreen.qml
@@ -150,6 +150,17 @@ Item {
                 sites.sitesModel.retrieveSites("all");
             }
         } // btnAll
+        Label { Layout.preferredHeight: 150 } // spacer
+        BackdeckButton {
+            id: btnSettings
+            anchors.bottom: tvSites.bottom
+            text: qsTr("Settings")
+            Layout.preferredWidth: 120
+            Layout.preferredHeight: 60
+            onClicked: {
+                smBackdeck.to_settings_state()
+            }
+        } // btnSettings
     }
 
     OkayCancelDialog {

--- a/qrc/survey_backdeck.qrc
+++ b/qrc/survey_backdeck.qrc
@@ -8,6 +8,7 @@
         <file>../qml/survey_backdeck/OperationSelectionScreen.qml</file>
         <file>../qml/survey_backdeck/FishSamplingScreen.qml</file>
         <file>../qml/survey_backdeck/SitesScreen.qml</file>
+        <file>../qml/survey_backdeck/SettingsScreen.qml</file>
 
         <!-- Widgets -->
         <file>../qml/survey_backdeck/BackdeckMenuButton.qml</file>
@@ -57,6 +58,7 @@
         <file>../qml/common/TrawlBackdeckTableView.qml</file>
         <file>../qml/common/TrawlBackdeckButton.qml</file>
         <file>../qml/common/TrawlNoteDialog.qml</file>
+        <file>../qml/common/FramComboBox.qml</file>
 
 
 


### PR DESCRIPTION
Adding ability to update IP address in UI in Cutter Station
1. Connect settings class to SETTINGS table via FramListModel
2. Load up settings model in UI on new settings page as editable tableview
3. Adjust StateMachine for nav purposes
4. When user makes edit, ask to confirm if value has changed
5. Also allow user to select hardcoded defaults for 2021 vessels
6. If IP Address value changes, reboot app