### PR TITLE
FIELD-1900: Rounding error fix, FIELD-2125 nav fix

### DIFF
--- a/py/observer/ObserverConfig.py
+++ b/py/observer/ObserverConfig.py
@@ -41,7 +41,7 @@ that each build has a unique version string which could be used to bring up the 
 as it stood for that particular build.  
 """
 
-optecs_version = "2.2.0+0"
+optecs_version = "2.2.0+2"
 
 # Number of floating point decimal places to display for weight etc.
 display_decimal_places = 2
@@ -55,4 +55,4 @@ max_text_size_trips_note_field = 4000
 max_text_size_unhandled_exception_comment = 400
 max_text_size_observer_comments = max_text_size_trips_note_field - max_text_size_unhandled_exception_comment
 
-use_encrypted_database = True
+use_encrypted_database = False

--- a/py/observer/Sets.py
+++ b/py/observer/Sets.py
@@ -202,7 +202,8 @@ class Sets(QObject):
                 (SpeciesCompositionBaskets.fish_number_itq.is_null(False)) & # baskets with actual counts
                 (SpeciesCompositionItems.species.in_(species_ids))  # species associated with CC
             ).scalar()
-            avg = ObserverDBUtil.round_up(avg)  # round here, precision will propagate to downstream vals
+            # DO NOT ROUND HERE
+            # avg = ObserverDBUtil.round_up(avg)  # round here, precision will propagate to downstream vals
             self._logger.info(f"Retained avg for set {faid}, species_ids {species_ids} = {avg}")
             return avg
 
@@ -320,7 +321,8 @@ class Sets(QObject):
             self._logger.info(f"related species for {i.species.species} = {related_species}")
             avg = self._calculate_retained_spp_avg(related_species)
             try:
-                new_wt = avg * i.species_number
+                new_wt = ObserverDBUtil.round_up(avg * i.species_number)
+                self._logger.info(f"New rounded weight = {avg}*{i.species_number} = {new_wt}")
             except TypeError:
                 self._logger.warning(f"No ret avg for species {i.cname}, DO/Pred comp item {i.species_comp_item} wt = NULL")
                 null_species.append(i.cname)

--- a/qml/observer/ObserverHome.qml
+++ b/qml/observer/ObserverHome.qml
@@ -248,7 +248,8 @@ Item {
                             console.debug("ObserverHome showing Edit Trip")
                             hauls_sets_button.item_enabled = true;
                             end_button.item_enabled = true;
-                            if (appstate.trips.currentFisheryName) {  // FIELD-2107: Go to hauls only if fishery set
+                            // FIELD-2107: Go to hauls only if fishery set (and collection method)
+                            if (appstate.trips.currentFisheryName && appstate.trips.currentCollectionMethod) {
                                 haulsButtonElem.item_enabled = true;
                             }
                             modelHomeButtons.set(start_edit_idx, editTrawlElem);
@@ -269,7 +270,8 @@ Item {
                             console.debug("ObserverHome showing Edit FG Trip")
                             hauls_sets_button.item_enabled = true;
                             end_button.item_enabled = true;
-                            if (appstate.trips.currentFisheryName) {  // FIELD-2107: Go to sets only if fishery set
+                            // FIELD-2107: Go to sets only if fishery set (and collection method)
+                            if (appstate.trips.currentFisheryName && appstate.trips.currentCollectionMethod) {
                                 setsButtonElem.item_enabled = true;
                             }
                             modelHomeButtons.set(start_edit_idx, editFGElem);


### PR DESCRIPTION
Do not round average before performing DR/Predated calculation.  Also fixing ability to bypass "Catch Collection Method" entry on Trip Details page by going back out to home screen.