### PR TITLE
#266: Moving HooksScreen print buttons out of footer

### DIFF
--- a/qml/hookandline_hookmatrix/Footer.qml
+++ b/qml/hookandline_hookmatrix/Footer.qml
@@ -81,6 +81,10 @@ RowLayout {
     }
 
     function printTags(printer) {
+        /*
+        #266: function no longer used, but leaving in case
+        print buttons are one day used in footer again
+        */
         var equipment = "";
         switch (printer) {
             case "bow":
@@ -358,8 +362,8 @@ RowLayout {
             PropertyChanges { target: deleteTime; visible: false}
             PropertyChanges { target: lblMove; visible: false}
             PropertyChanges { target: lblSwap; visible: false}
-            PropertyChanges { target: printBow; visible: true}
-            PropertyChanges { target: printAft; visible: true}
+            PropertyChanges { target: printBow; visible: false}  // #266: removing printBow from hooks footer
+            PropertyChanges { target: printAft; visible: false}  // #266: removing printAft from hooks footer
 //            PropertyChanges { target: lblReprint; visible: true}
             PropertyChanges { target: lblSpeciesList; visible: true; }
             PropertyChanges {target: lblSpacer;  width: 100}

--- a/qml/hookandline_hookmatrix/HooksScreen.qml
+++ b/qml/hookandline_hookmatrix/HooksScreen.qml
@@ -28,21 +28,6 @@ Item {
     state: "short species list"
 
     Connections {
-        target: labelPrinter
-        onPrinterStatusReceived: receivedPrinterStatus(comport, success, message)
-    }
-    function receivedPrinterStatus(comport, success, message) {
-        var result = success ? "success" : "failed"
-        dlgOkay.message = "Print job to " + comport + " status: " + result;
-        if (result === "failed") {
-            dlgOkay.action = "Please try again";
-        } else {
-            dlgOkay.action = "Well done, continue on matey";
-        }
-        dlgOkay.open();
-    }
-
-    Connections {
         target: hook5
         onCurrentHookChanged: changeCurrentHook(hookNumber);
     } // onCurrentHookChanged

--- a/qml/hookandline_hookmatrix/HooksScreen.qml
+++ b/qml/hookandline_hookmatrix/HooksScreen.qml
@@ -203,6 +203,41 @@ Item {
             return cpButton;
         }
     }
+    function printTags(printer) {
+        /*
+        #266: moving this function from footer.qml to here
+        so we can move print buttons off footer
+        TODO: Move this function all to python so its not isolated on HooksScreen.qml
+        */
+        var equipment = "";
+        switch (printer) {
+            case "bow":
+                equipment = "Zebra Printer Bow";
+                break;
+            case "aft":
+                equipment = "Zebra Printer Aft";
+                break;
+            case "mid":
+                equipment = "Zebra Printer Aft";
+                break;
+        }
+        var angler = stateMachine.angler;
+        var drop = stateMachine.drop;
+        var hooks = {1: hook1, 2: hook2, 3: hook3,
+                     4: hook4, 5: hook5}
+        var species = null;
+        for (var i in hooks) {
+            species = hooks[i].tfHook.text;
+            if ((species !== "Bait Back") &&
+                (species !== "No Bait") &&
+                (species !== "No Hook") &&
+                (species !== "Multiple Hook") &&
+                (species !== "")) {
+                console.info('printing ADH:  angler=' + angler + ', drop=' + drop + ', hook=' + i + ', species=' + species);
+                labelPrinter.printADHLabel(equipment, angler, drop, i, species);  // emits signal back to dlg on sites
+            }
+        }
+    }
     Component {
         id: cpLabel
         Label {}
@@ -268,6 +303,7 @@ Item {
         anchors.left: clHooks.right
         anchors.leftMargin: 20
         anchors.top: clHooks.top
+        anchors.rightMargin: 20
 
         // column 1
         BackdeckButton {
@@ -530,6 +566,63 @@ Item {
         } // btnYellowtail
     } // glShortSpeciesList
 //    SwipeView {
+    ColumnLayout {
+    // columnlayout allows margins for vertical line separator
+        id: clSpacer
+        anchors {
+            top: glShortSpeciesList.top
+            bottom: glShortSpeciesList.bottom
+            left: glShortSpeciesList.right
+        }
+        Rectangle {
+            Layout.rightMargin: 50
+            Layout.leftMargin: 50
+            anchors {
+                top: parent.top
+                bottom: parent.bottom
+                topMargin: 20
+                bottomMargin: piIndicator.visible ? 110 : 20
+            }
+            width: 2
+            color: "gray"
+        }
+    }
+    ColumnLayout {
+        // #266: print buttons moved from footer to here
+        id: clPrint
+        anchors.left: clSpacer.right
+        anchors.top: clSpacer.top
+        spacing: 20
+        Label {
+            text: "Print Tags"
+            font.pixelSize: 24
+            font.underline: true
+            font.bold: true
+            horizontalAlignment: Text.AlignLeft
+            Layout.preferredWidth: 200
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignRight
+        }
+        BackdeckButton {
+            id: btnPrintBow
+            text: qsTr("Bow")
+            Layout.preferredWidth: buttonWidth
+            Layout.preferredHeight: buttonHeight
+            onClicked: {
+                printTags("bow");
+            }
+        }
+        BackdeckButton {
+            id: btnPrintAft
+            text: qsTr("Aft")
+            Layout.preferredWidth: buttonWidth
+            Layout.preferredHeight: buttonHeight
+            onClicked: {
+                printTags("aft");
+            }
+        }
+    }
+
     Item {
         id: svFullSpeciesList
 //        currentIndex: 0

--- a/qml/hookandline_hookmatrix/SitesScreen.qml
+++ b/qml/hookandline_hookmatrix/SitesScreen.qml
@@ -11,6 +11,7 @@ Item {
         onPrinterStatusReceived: receivedPrinterStatus(comport, success, message)
     }
     function receivedPrinterStatus(comport, success, message) {
+    // #267: Dialog used by both test print (SettingsScreen.qml) and tag print (HooksScreen.qml)
         var result = success ? "success" : "failed"
         dlgOkay.message = "Print job to " + comport + " status: " + result;
         if (result === "failed") {


### PR DESCRIPTION
Print tag buttons for hooks should now be easier to click since they're off the footer and on the right-hand margin of the screen.  Also included is fix for #267 to avoid duplicate print confirmation popup.

Fix #267 
Fix #266